### PR TITLE
Implement cond and macros in Lisp evaluator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Whenever adding or modifying features in this repository, make sure to update README.md to reflect the current capabilities. Run `pytest -q` before committing to ensure all tests pass.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,11 @@
+# Future LispFun Enhancements
+
+This file collects ideas for features we would like to implement but have not yet addressed.
+
+- **Loop constructs** such as `while` or `for` to complement recursive iteration.
+- **Quasiquote and unquote** to simplify macro writing.
+- **Module system** for organizing code and supporting imports.
+- **File I/O primitives** for reading from and writing to files within Lisp.
+- **Exception handling** to manage runtime errors gracefully.
+- **Full self-hosting**: run the Lisp evaluator written in Lisp using itself.
+- **Expanded standard library** providing utilities beyond the basic list functions.

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 6. **Future Ideas**
    - Explore self-hosting (running the interpreter written in Lisp using itself).
    - Consider building a small standard library in Lisp for common utilities.
+   - See `IDEAS.md` for additional ideas to explore.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 2. **Testing Basic Programs**
    - Provide unit tests demonstrating that simple Lisp programs evaluate correctly.
    - Example programs: arithmetic computations, defining and calling functions.
+   - A Lisp test script (`selftest.lisp`) returns 1 when all tests pass, allowing Python to verify functionality by running it through the Lisp evaluator.
 
 3. **Self-hosted Evaluator (Lisp)**
    - Write a Lisp evaluator in Lisp, running on the Python interpreter.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 4. **Expanding Features in Lisp**
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
-   - Current progress: the Lisp evaluator now supports the `cond` form and `define-macro` for basic macros.
+   - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, and Lisp implementations of `null?`, `length`, `map`, and `filter`.
 
 4.5 **Testing Expanded Lisp Features**
    - Extend the test suite to exercise new Lisp features as they are added.
-   - The `tests/lisp/selftest.lisp` script performs assertions for `cond`, macros, and list operations and returns `1` when they succeed.
+   - The `tests/lisp/selftest.lisp` script performs assertions for `cond`, macros, and higher-order list utilities such as `length`, `map`, and `filter`, returning `1` when they succeed.
    - Python tests run this script via the Lisp evaluator to ensure feature parity.
 
 5. **Documentation and Examples**

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 4. **Expanding Features in Lisp**
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
+   - Current progress: the Lisp evaluator now supports the `cond` form and `define-macro` for basic macros.
 
 5. **Documentation and Examples**
    - Document usage of the interpreter and provide example Lisp programs.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
    - Current progress: the Lisp evaluator now supports the `cond` form and `define-macro` for basic macros.
 
+4.5 **Testing Expanded Lisp Features**
+   - Extend the test suite to exercise new Lisp features as they are added.
+   - The `tests/lisp/selftest.lisp` script performs assertions for `cond`, macros, and list operations and returns `1` when they succeed.
+   - Python tests run this script via the Lisp evaluator to ensure feature parity.
+
 5. **Documentation and Examples**
    - Document usage of the interpreter and provide example Lisp programs.
 

--- a/lispfun/evaluator.lisp
+++ b/lispfun/evaluator.lisp
@@ -52,5 +52,29 @@
                                                 (eval2 op env))))))))))
              )
              (car x)
-             (cdr x))
+            (cdr x))
             x))))
+
+(define null?
+  (lambda (x)
+    (= x (quote ()))) )
+
+(define length
+  (lambda (lst)
+    (if (null? lst)
+        0
+        (+ 1 (length (cdr lst))))))
+
+(define map
+  (lambda (f lst)
+    (if (null? lst)
+        (quote ())
+        (cons (f (car lst)) (map f (cdr lst))))) )
+
+(define filter
+  (lambda (pred lst)
+    (if (null? lst)
+        (quote ())
+        (if (pred (car lst))
+            (cons (car lst) (filter pred (cdr lst)))
+            (filter pred (cdr lst))))) )

--- a/lispfun/evaluator.lisp
+++ b/lispfun/evaluator.lisp
@@ -6,6 +6,18 @@
           (eval2 (car es) env)
           (eval-begin (cdr es) env)))) )
 
+(define eval-cond
+  (lambda (clauses env)
+    (if (= clauses (quote ()))
+        None
+        ((lambda (clause)
+           (if (= (car clause) (quote else))
+               (eval2 (car (cdr clause)) env)
+               (if (eval2 (car clause) env)
+                   (eval2 (car (cdr clause)) env)
+                   (eval-cond (cdr clauses) env))))
+         (car clauses)))) )
+
 (define eval2
   (lambda (x env)
     (if (symbol? x)
@@ -27,8 +39,17 @@
                                    (make-procedure (car args) (car (cdr args)) env)
                                    (if (= op (quote begin))
                                        (eval-begin args env)
-                                       (apply (eval2 op env)
-                                              (map (lambda (a) (eval2 a env)) args))))))))
+                                       (if (= op (quote cond))
+                                           (eval-cond args env)
+                                           (if (= op (quote define-macro))
+                                               (env-set! env (car args) (list (quote macro) (eval2 (car (cdr args)) env)))
+                                               ((lambda (proc)
+                                                  (if (list? proc)
+                                                      (if (= (car proc) (quote macro))
+                                                          (eval2 (apply (car (cdr proc)) args) env)
+                                                          (apply proc (map (lambda (a) (eval2 a env)) args)))
+                                                      (apply proc (map (lambda (a) (eval2 a env)) args))))
+                                                (eval2 op env))))))))))
              )
              (car x)
              (cdr x))

--- a/tests/lisp/selftest.lisp
+++ b/tests/lisp/selftest.lisp
@@ -14,4 +14,7 @@
 (begin
   (define-macro when (lambda (test expr) (list (quote if) test expr 0)))
   (assert-equal (when (> 3 2) 42) 42))
+(assert-equal (length (list 1 2 3)) 3)
+(assert-equal (map (lambda (x) (+ x 1)) (list 1 2 3)) (list 2 3 4))
+(assert-equal (filter (lambda (x) (> x 2)) (list 1 2 3 4)) (list 3 4))
 pass

--- a/tests/lisp/selftest.lisp
+++ b/tests/lisp/selftest.lisp
@@ -1,0 +1,17 @@
+(define pass 1)
+(define assert-equal
+  (lambda (result expected)
+    (if (= result expected)
+        1
+        (begin (set! pass 0) 0))) )
+
+(assert-equal (+ 1 2 3) 6)
+(assert-equal (begin (define x 4) x) 4)
+(assert-equal ((lambda (a b) (+ a b)) 3 4) 7)
+(assert-equal (if (> 3 2) 1 0) 1)
+(assert-equal (car (list 1 2 3)) 1)
+(assert-equal (cond ((> 3 4) 0) ((< 3 4) 1) (else 2)) 1)
+(begin
+  (define-macro when (lambda (test expr) (list (quote if) test expr 0)))
+  (assert-equal (when (> 3 2) 42) 42))
+pass

--- a/tests/test_lisp_files.py
+++ b/tests/test_lisp_files.py
@@ -7,6 +7,7 @@ from lispfun.interpreter import parse_multiple, eval_lisp, standard_env, to_stri
 EVAL_FILE = os.path.join(os.path.dirname(__file__), "..", "lispfun", "evaluator.lisp")
 BASIC_TEST = os.path.join(os.path.dirname(__file__), "lisp", "basic.lisp")
 BOOTSTRAP_TEST = os.path.join(os.path.dirname(__file__), "lisp", "bootstrap.lisp")
+SELFTEST_FILE = os.path.join(os.path.dirname(__file__), "lisp", "selftest.lisp")
 
 
 def run_file_with_eval(file_path):
@@ -47,5 +48,9 @@ def test_bootstrap_file_eval2():
 
 def test_basic_file_eval2():
     assert run_file_with_eval2(BASIC_TEST) == [6, 4, 5, 7, 1, 1, [2, 3], [0, 1, 2, 3], [1, 2]]
+
+
+def test_selftest_script():
+    assert run_file_with_eval2(SELFTEST_FILE) == 1
 
 

--- a/tests/test_self_eval.py
+++ b/tests/test_self_eval.py
@@ -63,3 +63,16 @@ def test_self_set_and_begin():
     assert eval_lisp(parse("(eval2 (quote (begin (set! z 4) z)) env)"), env) == 4
 
 
+def test_self_cond():
+    env = setup_env()
+    expr = "(cond ((> 3 4) 0) ((< 3 4) 1) (else 2))"
+    assert eval_lisp(parse(f"(eval2 (quote {expr}) env)"), env) == 1
+
+
+def test_self_macro():
+    env = setup_env()
+    define = "(define-macro when (lambda (test expr) (list (quote if) test expr 0)))"
+    eval_lisp(parse(f"(eval2 (quote {define}) env)"), env)
+    assert eval_lisp(parse("(eval2 (quote (when (> 3 2) 42)) env)"), env) == 42
+
+

--- a/tests/test_self_eval.py
+++ b/tests/test_self_eval.py
@@ -76,3 +76,17 @@ def test_self_macro():
     assert eval_lisp(parse("(eval2 (quote (when (> 3 2) 42)) env)"), env) == 42
 
 
+def test_self_list_utilities():
+    env = setup_env()
+    assert eval_lisp(parse("(eval2 (quote (null? (quote ())) ) env)"), env)
+    assert eval_lisp(parse("(eval2 (quote (length (list 1 2 3))) env)"), env) == 3
+
+
+def test_self_map_filter():
+    env = setup_env()
+    eval_lisp(parse("(eval2 (quote (define add1 (lambda (x) (+ x 1))) ) env)"), env)
+    assert eval_lisp(parse("(eval2 (quote (map add1 (list 1 2 3))) env)"), env) == [2, 3, 4]
+    expr = "(filter (lambda (x) (> x 2)) (list 1 2 3 4))"
+    assert eval_lisp(parse(f"(eval2 (quote {expr}) env)"), env) == [3, 4]
+
+


### PR DESCRIPTION
## Summary
- create AGENTS.md with guidance to keep README updated and run tests
- extend `evaluator.lisp` with `cond` and a `define-macro` facility
- add tests for the new features
- update README with progress on expanded features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687692d87b28832a89c498e79faef225