### PR TITLE
Enhance REPL usability with readline history

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ python -m lispfun [path/to/script.lisp]
 Running without a file starts an interactive REPL. Executing `run.py` directly
 (`python lispfun/run.py`) will fail because it relies on relative imports.
 
+The REPL supports command history if Python's `readline` module is available.
+Use the up and down arrow keys to navigate through previous inputs, similar to
+the bash shell.
+

--- a/lispfun/run.py
+++ b/lispfun/run.py
@@ -4,6 +4,21 @@ from .interpreter import (
     parse, parse_multiple, eval_lisp, standard_env, to_string
 )
 
+# Enable command history and up-arrow navigation if readline is available
+try:
+    import readline  # type: ignore
+    import atexit
+
+    HISTORY_FILE = os.path.join(os.path.expanduser("~"), ".lispfun_history")
+    readline.parse_and_bind("tab: complete")
+    try:
+        readline.read_history_file(HISTORY_FILE)
+    except FileNotFoundError:
+        pass
+    atexit.register(readline.write_history_file, HISTORY_FILE)
+except Exception:  # pragma: no cover - optional enhancement
+    readline = None  # fallback when readline isn't available
+
 EVAL_FILE = os.path.join(os.path.dirname(__file__), "evaluator.lisp")
 
 
@@ -36,6 +51,8 @@ def repl(env):
             line = input("lispfun> ")
             if not line:
                 continue
+            if readline:
+                readline.add_history(line)
             exp = parse(line)
             val = eval_with_eval2(exp, env)
             if val is not None:


### PR DESCRIPTION
## Summary
- enable readline support and persistent history for the REPL
- document readline history capability in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a1ff164c832aa8211b8e061e3441