### PR TITLE
Expose parse functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
    - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, and basic string literals.
+   - The environment also exposes Python's `parse` and `parse-multiple` functions, allowing Lisp code to read expressions from strings.
 
 4.5 **Testing Expanded Lisp Features**
    - Extend the test suite to exercise new Lisp features as they are added.

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -138,6 +138,9 @@ def standard_env() -> Environment:
         'symbol?': lambda x: isinstance(x, Symbol),
         'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
+        # parsing helpers
+        'parse': parse,
+        'parse-multiple': parse_multiple,
     })
     # helpers for the self-hosted evaluator
     env.update({

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -50,3 +50,14 @@ def test_string_literal_and_print(capsys):
     assert captured.out.strip() == 'hello world'
     assert eval_lisp(parse('(quote "hi there")'), env) == 'hi there'
 
+
+def test_parse_helpers():
+    env = standard_env()
+    parsed = eval_lisp(parse('(parse "(+ 1 2)")'), env)
+    assert eval_lisp(parsed, env) == 3
+    exprs = eval_lisp(parse('(parse-multiple "(define x 5) (+ x 1)")'), env)
+    result = None
+    for exp in exprs:
+        result = eval_lisp(exp, env)
+    assert result == 6
+

--- a/tests/test_self_eval.py
+++ b/tests/test_self_eval.py
@@ -2,7 +2,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from lispfun.interpreter import parse, parse_multiple, eval_lisp, standard_env
+from lispfun.interpreter import parse, parse_multiple, eval_lisp, standard_env, to_string
 
 EVAL_FILE = os.path.join(os.path.dirname(__file__), "..", "lispfun", "evaluator.lisp")
 
@@ -92,5 +92,17 @@ def test_self_map_filter():
     assert eval_lisp(parse("(eval2 (quote (map add1 (list 1 2 3))) env)"), env) == [2, 3, 4]
     expr = "(filter (lambda (x) (> x 2)) (list 1 2 3 4))"
     assert eval_lisp(parse(f"(eval2 (quote {expr}) env)"), env) == [3, 4]
+
+
+def test_self_parse_helpers():
+    env = setup_env()
+    parsed = eval_lisp(parse("(eval2 (quote (parse \"(+ 1 2)\") ) env)"), env)
+    result = eval_lisp(parse(f"(eval2 (quote {to_string(parsed)}) env)"), env)
+    assert result == 3
+    exprs = eval_lisp(parse("(eval2 (quote (parse-multiple \"(define y 5) (+ y 1)\") ) env)"), env)
+    result = None
+    for e in exprs:
+        result = eval_lisp(parse(f"(eval2 (quote {to_string(e)}) env)"), env)
+    assert result == 6
 
 


### PR DESCRIPTION
## Summary
- allow Lisp programs to call `parse` and `parse-multiple`
- document the new parsing helpers
- test parsing in both Python evaluator and self-hosted evaluator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ab32eaa4832a9ea2fbebca6338b1