### PR TITLE
Add plan for Lisp parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,6 @@ Currently, the interpreter in `lispfun/interpreter.py` still tokenizes and parse
 4. creation of symbol objects inside the Lisp environment.
 
 Once these components exist in Lisp, Python's role can shrink to simply loading the evaluator and starting the REPL.
+
+For a concrete checklist toward building a self-hosted parser, see
+`docs/pure_lisp_plan.md`.

--- a/docs/pure_lisp_plan.md
+++ b/docs/pure_lisp_plan.md
@@ -1,0 +1,24 @@
+# Plan for a Pure Lisp Parser
+
+The long term goal of **LispFun** is to load and interpret programs entirely in Lisp.  These steps outline how to replace the current Python tokenizer and reader with Lisp implementations.
+
+1. **String Utilities**
+   - Implement helpers in Lisp for iterating over characters in a string.
+   - Provide operations for building and slicing strings so the tokenizer can read source text one character at a time.
+
+2. **Expose Primitive Constructors**
+   - Extend `standard_env` with functions to create `Symbol` objects from Lisp code.
+   - Add utilities that convert sequences of digit characters into integers or floats.
+
+3. **Tokenizer and Reader in Lisp**
+   - Write a tokenizer in Lisp mirroring the behavior of Python's `tokenize` function in `interpreter.py`.
+   - Implement a `read-from-tokens` procedure that produces lists and atoms just like Python's `read_from_tokens`.
+
+4. **Integrate with the Runner**
+   - Update `run.py` so the Lisp parser can be loaded optionally.
+   - When available, parse input using the Lisp tokenizer and reader before evaluating with `eval2`.
+
+Once these pieces are in place, Python will only start the REPL and load the Lisp parser and evaluator.
+
+**Testing**
+- Remember to extend the test suite to cover the Lisp parser once it's implemented. Tests should run both the Python and Lisp parsing paths.


### PR DESCRIPTION
## Summary
- describe next steps for self-hosting the parser in `docs/pure_lisp_plan.md`
- cross-link the new plan from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b5fdede8832a8d32cd0bde2111bf