### PR TITLE
Implement Lisp parse-string function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 4. **Expanding Features in Lisp**
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
-   - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, and basic string literals.
+   - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, and includes a Lisp `parse-string` routine for reading string tokens.
 
 4.5 **Testing Expanded Lisp Features**
    - Extend the test suite to exercise new Lisp features as they are added.

--- a/lispfun/evaluator.lisp
+++ b/lispfun/evaluator.lisp
@@ -78,3 +78,19 @@
         (if (pred (car lst))
             (cons (car lst) (filter pred (cdr lst)))
             (filter pred (cdr lst))))) )
+
+
+(define parse-string
+  (lambda (text idx)
+    (begin
+      (define len (string-length text))
+      (define loop
+        (lambda (acc i)
+          (if (>= i len)
+              (list (make-string acc) i)
+              (begin
+                (define c (string-slice text i (+ i 1)))
+                (if (= (char-code c) 34)
+                    (list (make-string acc) (+ i 1))
+                    (loop (string-concat acc c) (+ i 1)))))))
+      (loop "" (+ idx 1)))))

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -138,6 +138,13 @@ def standard_env() -> Environment:
         'symbol?': lambda x: isinstance(x, Symbol),
         'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
+        # string utilities
+        'string-length': len,
+        'string-slice': lambda s, start, end: s[start:end],
+        'string-concat': lambda a, b: a + b,
+        'make-string': String,
+        'char-code': lambda s: ord(s[0]),
+        'chr': chr,
     })
     # helpers for the self-hosted evaluator
     env.update({

--- a/tests/lisp/stringparse.lisp
+++ b/tests/lisp/stringparse.lisp
@@ -1,0 +1,15 @@
+(define pass 1)
+(define assert-equal
+  (lambda (result expected)
+    (if (= result expected)
+        1
+        (begin (set! pass 0) 0))))
+
+(define q (chr 34))
+(define text (string-concat q "abc"))
+(set! text (string-concat text q))
+(set! text (string-concat text " rest"))
+(define parsed (parse-string text 0))
+(assert-equal (car parsed) "abc")
+(assert-equal (car (cdr parsed)) 5)
+pass

--- a/tests/test_lisp_files.py
+++ b/tests/test_lisp_files.py
@@ -8,6 +8,7 @@ EVAL_FILE = os.path.join(os.path.dirname(__file__), "..", "lispfun", "evaluator.
 BASIC_TEST = os.path.join(os.path.dirname(__file__), "lisp", "basic.lisp")
 BOOTSTRAP_TEST = os.path.join(os.path.dirname(__file__), "lisp", "bootstrap.lisp")
 SELFTEST_FILE = os.path.join(os.path.dirname(__file__), "lisp", "selftest.lisp")
+STRINGPARSE_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringparse.lisp")
 
 
 def run_file_with_eval(file_path):
@@ -52,5 +53,9 @@ def test_basic_file_eval2():
 
 def test_selftest_script():
     assert run_file_with_eval2(SELFTEST_FILE) == 1
+
+
+def test_stringparse_script():
+    assert run_file_with_eval2(STRINGPARSE_FILE) == 1
 
 


### PR DESCRIPTION
## Summary
- support character utilities in the Python environment
- implement `parse-string` in `evaluator.lisp`
- add tests for the Lisp string parser
- document the new parser feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ba272eb4832ab74676e34c9b6b69