### PR TITLE
Add import function to load Lisp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 4. **Expanding Features in Lisp**
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
-   - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, and includes a Lisp `parse-string` routine for reading string tokens.
+   - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, includes a Lisp `parse-string` routine for reading string tokens, and a Python-level `(import "file")` function for loading additional Lisp code.
 
 4.5 **Testing Expanded Lisp Features**
    - Extend the test suite to exercise new Lisp features as they are added.

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -152,6 +152,18 @@ def standard_env() -> Environment:
         'env-set!': lambda env, var, val: env.__setitem__(var, val),
         'make-procedure': Procedure,
     })
+    # ability to load additional Lisp files
+    def import_file(fname: str):
+        with open(str(fname)) as f:
+            code = f.read()
+        result = None
+        for exp in parse_multiple(code):
+            result = eval_lisp(exp, env)
+        return result
+
+    env.update({
+        'import': import_file,
+    })
     return env
 
 

--- a/tests/lisp/import_main.lisp
+++ b/tests/lisp/import_main.lisp
@@ -1,0 +1,2 @@
+(import "tests/lisp/import_support.lisp")
+(inc 41)

--- a/tests/lisp/import_support.lisp
+++ b/tests/lisp/import_support.lisp
@@ -1,0 +1,1 @@
+(define inc (lambda (x) (+ x 1)))

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,22 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lispfun.interpreter import parse, eval_lisp, standard_env
+from lispfun.run import load_eval, run_file
+
+SUPPORT = os.path.join(os.path.dirname(__file__), "lisp", "import_support.lisp")
+MAIN = os.path.join(os.path.dirname(__file__), "lisp", "import_main.lisp")
+
+
+def test_import_function():
+    env = standard_env()
+    eval_lisp(parse(f'(import "{SUPPORT}")'), env)
+    assert eval_lisp(parse('(inc 1)'), env) == 2
+
+
+def test_import_in_file_eval2():
+    env = standard_env()
+    load_eval(env)
+    result = run_file(MAIN, env)
+    assert result == 42


### PR DESCRIPTION
## Summary
- allow importing of Lisp files from other scripts
- document new `(import ...)` feature in README
- add tests for new import functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c5db112c832a93f788fa0bc65431