### PR TITLE
Add example Lisp programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ The REPL supports command history if Python's `readline` module is available.
 Use the up and down arrow keys to navigate through previous inputs, similar to
 the bash shell.
 
+## Example Programs
+
+Several small example scripts live in the `examples` directory. Run them with
+
+```bash
+python -m lispfun examples/<script>.lisp
+```
+
+Available scripts:
+
+- `factorial.lisp` – recursive factorial calculation
+- `fibonacci.lisp` – compute Fibonacci numbers
+- `list-demo.lisp` – demonstrate `length`, `map` and `filter`
+- `macro-example.lisp` – use a simple `when` macro
+
 ## Self-hosted Evaluator
 
 The self-hosted interpreter lives in `lispfun/evaluator.lisp`. It is loaded by `load_eval` in `lispfun/run.py` (lines 10-15) so that the Lisp version of the evaluator can run within the Python environment. Expressions are then executed by calling `eval_with_eval2` (lines 18-20) which invokes the Lisp function `eval2` rather than Python's `eval_lisp`.

--- a/examples/factorial.lisp
+++ b/examples/factorial.lisp
@@ -1,0 +1,6 @@
+(define fact
+  (lambda (n)
+    (if (= n 0)
+        1
+        (* n (fact (- n 1))))))
+(print (fact 5))

--- a/examples/fibonacci.lisp
+++ b/examples/fibonacci.lisp
@@ -1,0 +1,6 @@
+(define fib
+  (lambda (n)
+    (if (< n 2)
+        n
+        (+ (fib (- n 1)) (fib (- n 2))))))
+(print (fib 7))

--- a/examples/list-demo.lisp
+++ b/examples/list-demo.lisp
@@ -1,0 +1,6 @@
+(define square (lambda (x) (* x x)))
+(define nums (list 1 2 3 4 5))
+(print (list
+  (length nums)
+  (map square nums)
+  (filter (lambda (x) (> x 2)) nums)))

--- a/examples/macro-example.lisp
+++ b/examples/macro-example.lisp
@@ -1,0 +1,8 @@
+(define-macro when
+  (lambda (test expr)
+    (list (quote if) test expr 0)))
+
+(begin
+  (define result 0)
+  (when (> 3 2) (set! result 42))
+  (print result))


### PR DESCRIPTION
## Summary
- add simple Lisp example scripts
- document how to run them in README

## Testing
- `pytest -q`
- `python -m lispfun examples/factorial.lisp`
- `python -m lispfun examples/fibonacci.lisp`
- `python -m lispfun examples/list-demo.lisp`
- `python -m lispfun examples/macro-example.lisp`


------
https://chatgpt.com/codex/tasks/task_e_6876c68f35f0832aa054c4478cf2b180