### PR TITLE
Add toy-runner example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Available scripts:
 - `list-demo.lisp` – demonstrate `length`, `map` and `filter`
 - `macro-example.lisp` – use a simple `when` macro
 - `toy-interpreter.lisp` – illustrative Lisp interpreter written in Lisp
+- `toy-runner.lisp` – load the toy interpreter and run all other examples
 
 ### Toy Interpreter Usage
 

--- a/examples/toy-runner.lisp
+++ b/examples/toy-runner.lisp
@@ -1,0 +1,6 @@
+(import "examples/toy-interpreter.lisp")
+
+(run-file "examples/factorial.lisp")
+(run-file "examples/fibonacci.lisp")
+(run-file "examples/list-demo.lisp")
+(run-file "examples/macro-example.lisp")


### PR DESCRIPTION
## Summary
- add `toy-runner.lisp` to demonstrate running multiple examples
- document the new example in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e83c7b7c832a93fc515b789cb568