### PR TITLE
Add string iteration helpers and parsing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 4. **Expanding Features in Lisp**
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
-  - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, includes a Lisp `parse-string` routine for reading string tokens, and a Python-level `(import "file")` function for loading additional Lisp code.  The evaluator itself is split into multiple files that are loaded via `(import ...)` from `evaluator.lisp`.
+  - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, utilities like `parse-string`, `string-for-each`, and `build-string` for working with text, and a Python-level `(import "file")` function for loading additional Lisp code.  The evaluator itself is split into multiple files that are loaded via `(import ...)` from `evaluator.lisp`.
 
 4.5 **Testing Expanded Lisp Features**
    - Extend the test suite to exercise new Lisp features as they are added.
@@ -85,17 +85,15 @@ string, which `run-file` relies on.
 
 The self-hosted interpreter now spans several Lisp files in the `lispfun/` directory.  The entry point `evaluator.lisp` loads helper modules using the Lisp `(import ...)` function.  `load_eval` in `lispfun/run.py` reads this entry file so that the Lisp evaluator can run within the Python environment.  Expressions are then executed by calling `eval_with_eval2`, which invokes the Lisp function `eval2` defined in `eval_core.lisp` rather than Python's `eval_lisp`.
 
-List utilities live in `list_utils.lisp` and the string helper `parse-string` resides in `string_utils.lisp`.  These modules are imported automatically when `evaluator.lisp` is loaded.
+List utilities live in `list_utils.lisp` and string helpers such as `parse-string`, `string-for-each`, and `build-string` reside in `string_utils.lisp`.  These modules are imported automatically when `evaluator.lisp` is loaded.
 
 ## Future Self-Hosting Goals
 
 The long-term vision is for Python to serve purely as a thin loader and REPL interface.  All parsing and evaluation will ultimately happen in Lisp.
-Currently, the interpreter in `lispfun/interpreter.py` still tokenizes and parses source code in Python and represents identifiers using the Python `Symbol` class.  To shift these responsibilities into Lisp we need to reimplement several pieces:
+Currently, the interpreter in `lispfun/interpreter.py` still tokenizes and parses source code in Python.  Helpers now exist to create `Symbol` objects and convert digit sequences to numbers from Lisp code.  To finish moving the parser we must implement:
 
 1. a tokenizer that splits program text into Lisp tokens,
-2. a reader for building lists and atoms from those tokens,
-3. numeric conversion utilities to create integers and floats, and
-4. creation of symbol objects inside the Lisp environment.
+2. a reader for building lists and atoms from those tokens.
 
 Once these components exist in Lisp, Python's role can shrink to simply loading the evaluator and starting the REPL.
 

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -46,6 +46,9 @@ def standard_env() -> Environment:
         'make-string': String,
         'char-code': lambda s: ord(s[0]),
         'chr': chr,
+        # primitives used by Lisp parsing code
+        'make-symbol': lambda name: Symbol(str(name)),
+        'digits->number': lambda s: int(s) if '.' not in s else float(s),
     })
     # helpers for the self-hosted evaluator
     env.update({

--- a/lispfun/string_utils.lisp
+++ b/lispfun/string_utils.lisp
@@ -12,3 +12,27 @@
                     (list (make-string acc) (+ i 1))
                     (loop (string-concat acc c) (+ i 1)))))))
       (loop "" (+ idx 1)))) )
+
+(define string-for-each
+  (lambda (f s)
+    (begin
+      (define len (string-length s))
+      (define iter
+        (lambda (i)
+          (if (< i len)
+              (begin
+                (f (string-slice s i (+ i 1)))
+                (iter (+ i 1)))
+              0)))
+      (iter 0))))
+
+(define build-string
+  (lambda (n f)
+    (begin
+      (define iter
+        (lambda (i acc)
+          (if (>= i n)
+              (make-string acc)
+              (iter (+ i 1)
+                    (string-concat acc (f i))))) )
+      (iter 0 ""))))

--- a/tests/lisp/stringutils.lisp
+++ b/tests/lisp/stringutils.lisp
@@ -1,0 +1,21 @@
+(define pass 1)
+(define assert-equal
+  (lambda (result expected)
+    (if (= result expected)
+        1
+        (begin (set! pass 0) 0))))
+
+(define dummy (string-for-each (lambda (c) 0) "ab"))
+(assert-equal dummy 0)
+
+(define built (build-string 3 (lambda (i)
+                                (if (= i 0) "a" (if (= i 1) "b" "c")))))
+(assert-equal built "abc")
+
+(assert-equal (digits->number "123") 123)
+(assert-equal (digits->number "3.5") 3.5)
+
+(define sym (make-symbol "foo"))
+(assert-equal (symbol? sym) 1)
+
+pass

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import pytest
 from lispfun.interpreter import parse, eval_lisp, standard_env
+from lispfun.parser import Symbol
 
 
 def eval_prog(expr: str):
@@ -49,4 +50,15 @@ def test_string_literal_and_print(capsys):
     captured = capsys.readouterr()
     assert captured.out.strip() == 'hello world'
     assert eval_lisp(parse('(quote "hi there")'), env) == 'hi there'
+
+
+def test_symbol_and_digits_helpers():
+    env = standard_env()
+    make_sym = env['make-symbol']
+    digits_to_number = env['digits->number']
+    sym = make_sym('foo')
+    assert isinstance(sym, Symbol)
+    assert env['symbol?'](sym)
+    assert digits_to_number('123') == 123
+    assert digits_to_number('3.14') == 3.14
 

--- a/tests/test_lisp_files.py
+++ b/tests/test_lisp_files.py
@@ -9,6 +9,7 @@ BASIC_TEST = os.path.join(os.path.dirname(__file__), "lisp", "basic.lisp")
 BOOTSTRAP_TEST = os.path.join(os.path.dirname(__file__), "lisp", "bootstrap.lisp")
 SELFTEST_FILE = os.path.join(os.path.dirname(__file__), "lisp", "selftest.lisp")
 STRINGPARSE_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringparse.lisp")
+STRINGUTILS_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringutils.lisp")
 
 
 def run_file_with_eval(file_path):
@@ -57,5 +58,9 @@ def test_selftest_script():
 
 def test_stringparse_script():
     assert run_file_with_eval2(STRINGPARSE_FILE) == 1
+
+
+def test_stringutils_script():
+    assert run_file_with_eval2(STRINGUTILS_FILE) == 1
 
 


### PR DESCRIPTION
## Summary
- extend `string_utils.lisp` with `string-for-each` and `build-string`
- expose `make-symbol` and `digits->number` in `standard_env`
- update README to document added capabilities
- add regression tests for the new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876eb03a6f0832abbdcac4e3b893c4c