### PR TITLE
Add toy REPL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository aims to develop a minimal Lisp interpreter in Python and gradual
 4. **Expanding Features in Lisp**
    - Add more language features implemented in Lisp: conditionals, lists, higher-order functions, and macros.
    - Gradually reduce Python's role to just parsing and initial bootstrapping.
-  - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, utilities like `parse-string`, `string-for-each`, and `build-string` for working with text, and a Python-level `(import "file")` function for loading additional Lisp code.  The evaluator itself is split into multiple files that are loaded via `(import ...)` from `evaluator.lisp`.
+  - Current progress: the Lisp evaluator now supports the `cond` form, `define-macro` for basic macros, Lisp implementations of `null?`, `length`, `map`, and `filter`, basic string literals, utilities like `parse-string`, `string-for-each`, and `build-string` for working with text, a `read-line` primitive for interactive input, and a Python-level `(import "file")` function for loading additional Lisp code.  The evaluator itself is split into multiple files that are loaded via `(import ...)` from `evaluator.lisp`.
 
 4.5 **Testing Expanded Lisp Features**
    - Extend the test suite to exercise new Lisp features as they are added.
@@ -68,6 +68,7 @@ Available scripts:
   The interpreter's code now lives in `toy-tokenizer.lisp`, `toy-parser.lisp`,
   and `toy-evaluator.lisp`, which `toy-interpreter.lisp` loads via `(import ...)`.
 - `toy-runner.lisp` – load the toy interpreter and run all other examples
+- `toy-repl.lisp` – simple REPL built on the toy interpreter
 
 ### Toy Interpreter Usage
 
@@ -82,6 +83,12 @@ python -m lispfun examples/toy-interpreter.lisp
 
 The helper `read-file` function is available to slurp a file's contents as a
 string, which `run-file` relies on.
+
+`toy-repl.lisp` uses the new `read-line` primitive to provide a minimal REPL:
+
+```bash
+python -m lispfun examples/toy-repl.lisp
+```
 
 ## Self-hosted Evaluator
 

--- a/examples/toy-evaluator.lisp
+++ b/examples/toy-evaluator.lisp
@@ -66,7 +66,8 @@
     (list "length" length)
     (list "map" map)
     (list "filter" filter)
-    (list "read-file" read-file)))
+    (list "read-file" read-file)
+    (list "read-line" read-line)))
 
 ; Convenience to evaluate a program string using the toy interpreter
 (define eval-string

--- a/examples/toy-repl.lisp
+++ b/examples/toy-repl.lisp
@@ -1,0 +1,13 @@
+(import "examples/toy-interpreter.lisp")
+
+; Minimal REPL using the toy evaluator.  Type "exit" to quit.
+(define toy-repl
+  (lambda ()
+    (define line (read-line "toy> "))
+    (if (= line "exit")
+        'bye
+        (begin
+          (print (eval-string line))
+          (toy-repl)))))
+
+(toy-repl)

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -39,6 +39,7 @@ def standard_env() -> Environment:
         'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
         'read-file': lambda fname: open(str(fname)).read(),
+        'read-line': lambda prompt='': input(prompt),
         # string utilities
         'string-length': len,
         'string-slice': lambda s, start, end: s[start:end],


### PR DESCRIPTION
## Summary
- expose `read-line` primitive in the Python environment and the toy evaluator
- add `toy-repl.lisp` example implementing a small REPL using the toy interpreter
- document the new example and primitive in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f56b4c10832a914f93a1a3b0e343