### PR TITLE
Improve read-file helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ python -m lispfun examples/toy-interpreter.lisp
 ```
 
 The helper `read-file` function is available to slurp a file's contents as a
-string, which `run-file` relies on.
+string, which `run-file` relies on. It now uses a context manager so files are
+closed properly.
 
 `toy-repl.lisp` uses the new `read-line` primitive to provide a minimal REPL:
 

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -2,6 +2,12 @@ from functools import reduce
 import operator as op
 from typing import Any, List
 
+
+def read_file(fname: str) -> str:
+    """Return the contents of *fname* as a string."""
+    with open(str(fname)) as f:
+        return f.read()
+
 from .parser import (
     Symbol,
     String,
@@ -38,7 +44,7 @@ def standard_env() -> Environment:
         'symbol?': lambda x: isinstance(x, Symbol),
         'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
-        'read-file': lambda fname: open(str(fname)).read(),
+        'read-file': read_file,
         'read-line': lambda prompt='': input(prompt),
         # string utilities
         'string-length': len,

--- a/tests/test_read_file.py
+++ b/tests/test_read_file.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lispfun.interpreter import parse, eval_lisp, standard_env
+
+
+def test_read_file(tmp_path):
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("hello")
+    env = standard_env()
+    result = eval_lisp(parse(f'(read-file "{file_path}")'), env)
+    assert result == "hello"


### PR DESCRIPTION
## Summary
- factor out `read-file` helper to use a context manager
- add a unit test covering `read-file`
- document the safer implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770dd0681c832a9e36b83415569205