### PR TITLE
Use toy interpreter when running files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Use Python's `-m` option from the repository root so that package imports resolv
 python -m lispfun [path/to/script.lisp]
 ```
 
-Running without a file starts an interactive REPL. Executing `run.py` directly
-(`python lispfun/run.py`) will fail because it relies on relative imports.
+Running without a file starts an interactive REPL. When provided a script path,
+`run.py` now loads the Lisp toy interpreter and invokes its `run-file` function
+to execute the program.  Executing `run.py` directly (`python lispfun/run.py`)
+still fails because it relies on relative imports.
 
 The REPL supports command history if Python's `readline` module is available.
 Use the up and down arrow keys to navigate through previous inputs, similar to

--- a/lispfun/run.py
+++ b/lispfun/run.py
@@ -20,6 +20,7 @@ except Exception:  # pragma: no cover - optional enhancement
     readline = None  # fallback when readline isn't available
 
 EVAL_FILE = os.path.join(os.path.dirname(__file__), "evaluator.lisp")
+TOY_FILE = os.path.join(os.path.dirname(__file__), "..", "examples", "toy-interpreter.lisp")
 
 
 def load_eval(env):
@@ -30,9 +31,24 @@ def load_eval(env):
     env["env"] = env
 
 
+def load_toy(env):
+    """Load the toy interpreter implemented in Lisp."""
+    with open(TOY_FILE) as f:
+        code = f.read()
+    for exp in parse_multiple(code):
+        eval_with_eval2(exp, env)
+
+
 def eval_with_eval2(exp, env):
     program = f"(eval2 (quote {to_string(exp)}) env)"
     return eval_lisp(parse(program), env)
+
+
+def toy_run_file(filename, env):
+    """Execute a Lisp script using the toy interpreter."""
+    load_toy(env)
+    program = parse(f'(run-file "{filename}")')
+    return eval_with_eval2(program, env)
 
 
 def run_file(filename, env):
@@ -68,7 +84,7 @@ def main():
     env = standard_env()
     load_eval(env)
     if len(sys.argv) > 1:
-        run_file(sys.argv[1], env)
+        toy_run_file(sys.argv[1], env)
     else:
         repl(env)
 


### PR DESCRIPTION
## Summary
- use toy interpreter when invoking `run.py` on a file
- keep original `run_file` for tests
- document the new behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770d18bbe4832a8daad824c4f55e8b