### PR TITLE
Add example script to run Lisp tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ python -m lispfun examples/toy-runner.lisp
 ```
 =======
 - `toy-repl.lisp` – simple REPL built on the toy interpreter
+- `run-tests.lisp` – run all test scripts in `tests/lisp`
 # >>>>>>> main
 
 ### Toy Interpreter Usage

--- a/examples/run-tests.lisp
+++ b/examples/run-tests.lisp
@@ -1,0 +1,9 @@
+; Run all Lisp tests using the built-in import facility.
+; Each imported file prints its result so you can verify success.
+
+(print (import "tests/lisp/bootstrap.lisp"))
+(print (import "tests/lisp/basic.lisp"))
+(print (import "tests/lisp/import_main.lisp"))
+(print (import "tests/lisp/selftest.lisp"))
+(print (import "tests/lisp/stringparse.lisp"))
+(print (import "tests/lisp/stringutils.lisp"))


### PR DESCRIPTION
## Summary
- add `examples/run-tests.lisp` for running test scripts under `tests/lisp`
- document the new example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770ecdaa50832aa451553d856dfca9