### PR TITLE
Improve example test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python -m lispfun examples/toy-runner.lisp
 ```bash
 python -m lispfun examples/toy-repl.lisp
 ```
-- `run-tests.lisp` – run all test scripts in `tests/lisp`
+- `run-tests.lisp` – defines a `run-test` helper and runs each script in `tests/lisp`
 
 ### Toy Interpreter Usage
 

--- a/examples/run-tests.lisp
+++ b/examples/run-tests.lisp
@@ -1,9 +1,16 @@
 ; Run all Lisp tests using the built-in import facility.
-; Each imported file prints its result so you can verify success.
+; Define a helper that announces each file before importing it so
+; it's clear which tests execute.
 
-(print (import "tests/lisp/bootstrap.lisp"))
-(print (import "tests/lisp/basic.lisp"))
-(print (import "tests/lisp/import_main.lisp"))
-(print (import "tests/lisp/selftest.lisp"))
-(print (import "tests/lisp/stringparse.lisp"))
-(print (import "tests/lisp/stringutils.lisp"))
+(define run-test
+  (lambda (file)
+    (begin
+      (print (string-concat "Running " file))
+      (print (import file)))))
+
+(run-test "tests/lisp/bootstrap.lisp")
+(run-test "tests/lisp/basic.lisp")
+(run-test "tests/lisp/import_main.lisp")
+(run-test "tests/lisp/selftest.lisp")
+(run-test "tests/lisp/stringparse.lisp")
+(run-test "tests/lisp/stringutils.lisp")

--- a/tests/test_lisp_files.py
+++ b/tests/test_lisp_files.py
@@ -99,7 +99,8 @@ def test_basic_file_eval2_lisp_parser():
 def test_selftest_script_lisp_parser():
     assert run_file_with_eval2_lisp_parser(SELFTEST_FILE) == 1
 
-    def test_stringparse_script():
+
+def test_stringparse_script():
     assert run_file_with_eval2(STRINGPARSE_FILE) == 1
 
 def test_stringutils_script():


### PR DESCRIPTION
## Summary
- make `run-tests.lisp` announce each file as it runs
- document the helper in README
- fix indentation in `tests/test_lisp_files.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68778ca4737c832aa8778d1007eb94a4