### PR TITLE
Refactor docs per interpreter

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,6 +1,8 @@
 # Future LispFun Enhancements
 
-This file collects ideas for features we would like to implement but have not yet addressed.
+This file collects ideas for features we would like to implement. Development is
+now focused on improving the Lisp toy interpreter found in
+`docs/toy_interpreter.md`.
 
 - **Loop constructs** such as `while` or `for` to complement recursive iteration.
 - **Quasiquote and unquote** to simplify macro writing.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ LispFun is a small Lisp interpreter written in Python with an increasing amount 
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing and macros.
 - A comprehensive unit test suite including a `selftest.lisp` script executed by the evaluator.
 
+## Documentation
+
+Separate documents describe each interpreter:
+
+- [Python bootstrap interpreter](docs/bootstrap_interpreter.md)
+- [Self-hosted evaluator](docs/self_hosted_evaluator.md)
+- [Lisp toy interpreter](docs/toy_interpreter.md)
+
 ## Running the Interpreter
 
 From the repository root use Python's `-m` switch so package imports resolve correctly:
@@ -42,9 +50,10 @@ Available scripts include:
 - `fibonacci.lisp` – compute Fibonacci numbers
 - `list-demo.lisp` – demonstrate list utilities
 - `macro-example.lisp` – use a simple `when` macro
-- `toy-interpreter.lisp` – illustrative Lisp interpreter written in Lisp.
-  The interpreter's code lives in `toy-tokenizer.lisp`, `toy-parser.lisp`
-  and `toy-evaluator.lisp`, which `toy-interpreter.lisp` loads via `(import ...)`.
+- `toy-interpreter.lisp` – illustrative Lisp interpreter written in Lisp. See
+  [docs/toy_interpreter.md](docs/toy_interpreter.md) for usage. The
+  interpreter's code lives in `toy-tokenizer.lisp`, `toy-parser.lisp` and
+  `toy-evaluator.lisp`, which `toy-interpreter.lisp` loads via `(import ...)`.
 - `toy-runner.lisp` – load the toy interpreter and run all other examples.
   This script exercises the toy interpreter by running each example file.
   With comment parsing support you can execute it directly:
@@ -59,23 +68,6 @@ python -m lispfun examples/toy-repl.lisp
 ```
 - `run-tests.lisp` – defines a `run-test` helper and runs each script in `tests/lisp`
 
-### Toy Interpreter Usage
-
-The `toy-*.lisp` files implement a complete tokenizer, parser, and evaluator
-written in Lisp. After Python loads the minimal `eval2` evaluator, the toy
-interpreter runs entirely in Lisp to execute programs. This approach shows how
-the project can bootstrap toward a fully self-hosted implementation.
-
-Run the Lisp-based interpreter itself and then use `run-file` to execute other
-examples:
-
-```bash
-python -m lispfun examples/toy-interpreter.lisp
-; once inside the REPL
-(run-file "examples/factorial.lisp")
-```
-
-The helper `read-file` function reads a file into a string and is used by `run-file`.
 
 ## Self-hosted Evaluator Details
 

--- a/docs/bootstrap_interpreter.md
+++ b/docs/bootstrap_interpreter.md
@@ -1,0 +1,11 @@
+# Python Bootstrap Interpreter
+
+The bootstrap interpreter in `interpreter.py` is the initial Python implementation of LispFun. It provides a REPL and basic evaluation of arithmetic, variables and functions. The environment exposes list and string helpers, `import` for loading Lisp files and primitives needed by the Lisp evaluator.
+
+Run the interpreter directly with:
+
+```bash
+python -m lispfun
+```
+
+Passing a path will execute that file using the built-in parser and evaluator.

--- a/docs/self_hosted_evaluator.md
+++ b/docs/self_hosted_evaluator.md
@@ -1,0 +1,5 @@
+# Self-hosted Evaluator
+
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator. The Python runner loads this file through `load_eval` in `run.py`. Once loaded, expressions are executed by wrapping them in `(eval2 ...)`.
+
+Helper modules such as `list_utils.lisp`, `string_utils.lisp` and `eval_core.lisp` provide primitives required by `eval2`. The evaluator understands macros defined with `define-macro` and is the foundation used by higher level code.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -1,0 +1,17 @@
+# Lisp Toy Interpreter
+
+The toy interpreter demonstrates how a complete Lisp system can be built in Lisp itself. It includes:
+
+- `toy-tokenizer.lisp` – converts source text into tokens.
+- `toy-parser.lisp` – builds lists and atoms from the token stream.
+- `toy-evaluator.lisp` – evaluates expressions using a simple environment.
+
+`toy-interpreter.lisp` loads these pieces and exposes helper functions such as `run-file` and a small REPL.
+
+Run the interpreter with:
+
+```bash
+python -m lispfun examples/toy-interpreter.lisp
+```
+
+Inside the REPL you can execute scripts using `(run-file "path/to/file.lisp")`.


### PR DESCRIPTION
## Summary
- split documentation into dedicated pages for each interpreter
- link to the new docs from the README
- remove inline toy interpreter usage details
- note new focus in IDEAS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687788108618832aaf0ff48bda07d0c6