### PR TITLE
Enable macros in toy interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ LispFun is a small Lisp interpreter written in Python with an increasing amount 
   - String helpers: `parse-string`, `string-for-each`, `build-string`.
   - `read-line` primitive for interactive input.
   - `(import "file")` for loading additional Lisp code.
+  - Toy interpreter supports `define-macro` so macros work when running example scripts.
 - Semicolon comments are recognized by the parser.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing and macros.
 - A comprehensive unit test suite including a `selftest.lisp` script executed by the evaluator.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -8,6 +8,8 @@ The toy interpreter demonstrates how a complete Lisp system can be built in Lisp
 
 `toy-interpreter.lisp` loads these pieces and exposes helper functions such as `run-file` and a small REPL.
 
+The evaluator supports `define-macro` so macros can be expanded when running code entirely in Lisp.
+
 Run the interpreter with:
 
 ```bash

--- a/examples/toy-evaluator.lisp
+++ b/examples/toy-evaluator.lisp
@@ -37,10 +37,18 @@
                  (extend-env global-env (list (cadr x))
                              (list (eval-expr (caddr x) env))))
            (quote ok)))
+        ((= (car x) 'define-macro)
+         (begin
+           (set! global-env
+                 (extend-env global-env (list (cadr x))
+                             (list (list 'macro (eval-expr (caddr x) env)))))
+           (quote ok)))
         (else
-          (let ((proc (eval-expr (car x) env))
-                (args (map (lambda (e) (eval-expr e env)) (cdr x))))
-            (apply-closure proc args))))
+         (let ((proc (eval-expr (car x) env)))
+           (if (and (list? proc) (= (car proc) 'macro))
+               (eval-expr (apply-closure (cadr proc) (cdr x)) env)
+               (let ((args (map (lambda (e) (eval-expr e env)) (cdr x))))
+                 (apply-closure proc args))))))
       (else
        (if (number? x)
            x

--- a/examples/toy-parser.lisp
+++ b/examples/toy-parser.lisp
@@ -24,3 +24,16 @@
 (define parse
   (lambda (text)
     (car (read-from-tokens (tokenize text)))))
+
+; Parse all expressions from a program string
+(define parse-multiple
+  (lambda (text)
+    (begin
+      (define tokens (tokenize text))
+      (define loop
+        (lambda (ts acc)
+          (if (null? ts)
+              (reverse acc)
+              (let ((res (read-from-tokens ts)))
+                (loop (cadr res) (cons (car res) acc))))))
+      (loop tokens (quote ())))))

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -68,8 +68,13 @@ def standard_env() -> Environment:
         with open(str(fname)) as f:
             code = f.read()
         result = None
-        for exp in parse_multiple(code):
-            result = eval_lisp(exp, env)
+        exprs = parse_multiple(code)
+        for exp in exprs:
+            if "eval2" in env:
+                program = f"(eval2 (quote {to_string(exp)}) env)"
+                result = eval_lisp(parse(program), env)
+            else:
+                result = eval_lisp(exp, env)
         return result
 
     env.update({


### PR DESCRIPTION
## Summary
- support `define-macro` in the toy evaluator
- expose new `parse-multiple` helper for the toy parser
- run `import` through `eval2` when available so macros expand
- document macro capability

## Testing
- `pytest -q`
- `python -m lispfun examples/run-tests.lisp`

------
https://chatgpt.com/codex/tasks/task_e_687792eeb0c0832ab281e8755aba34ec