### PR TITLE
Add runner scripts for bootstrap and toy interpreters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ Separate documents describe each interpreter:
 
 ## Running the Interpreter
 
-From the repository root use Python's `-m` switch so package imports resolve correctly:
+There are several helper scripts for running LispFun depending on how much Lisp code
+you wish to bootstrap:
 
 ```bash
-python -m lispfun [path/to/script.lisp]
+python run_bootstrap.py [file]   # pure Python interpreter
+python run_hosted.py [file]      # load evaluator.lisp and use eval2
+python run_toy.py [file]         # load evaluator and toy interpreter
 ```
 
-Running without a file starts the REPL.  When a script path is supplied the toy interpreter written in Lisp is loaded and its `run-file` function executes the program.
-
+Running without a file starts a REPL. `python -m lispfun` behaves like
+`run_hosted.py` but only loads the toy interpreter when executing a file.
 History support is enabled if the `readline` module is available.
 
 ## Example Programs

--- a/docs/bootstrap_interpreter.md
+++ b/docs/bootstrap_interpreter.md
@@ -5,7 +5,7 @@ The bootstrap interpreter in `interpreter.py` is the initial Python implementati
 Run the interpreter directly with:
 
 ```bash
-python -m lispfun
+python run_bootstrap.py [path/to/file.lisp]
 ```
 
-Passing a path will execute that file using the built-in parser and evaluator.
+Omit the path to start the REPL.

--- a/run_bootstrap.py
+++ b/run_bootstrap.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Run the pure Python bootstrap interpreter."""
+import sys
+from lispfun.interpreter import (
+    parse,
+    parse_multiple,
+    eval_lisp,
+    standard_env,
+    to_string,
+)
+
+
+def run_file(filename: str, env) -> None:
+    """Execute expressions from *filename* using *env*."""
+    with open(filename) as f:
+        code = f.read()
+    for exp in parse_multiple(code):
+        eval_lisp(exp, env)
+
+
+def repl(env) -> None:
+    """Interactive REPL using the bootstrap interpreter."""
+    while True:
+        try:
+            line = input("lispfun> ")
+            if not line:
+                continue
+            val = eval_lisp(parse(line), env)
+            if val is not None:
+                print(to_string(val))
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+def main() -> None:
+    env = standard_env()
+    if len(sys.argv) > 1:
+        run_file(sys.argv[1], env)
+    else:
+        repl(env)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_hosted.py
+++ b/run_hosted.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""Run the self-hosted evaluator via eval2."""
+import sys
+from lispfun.interpreter import standard_env
+from lispfun.run import load_eval, run_file, repl
+
+
+def main() -> None:
+    env = standard_env()
+    load_eval(env)
+    if len(sys.argv) > 1:
+        run_file(sys.argv[1], env)
+    else:
+        repl(env)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_toy.py
+++ b/run_toy.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""Run the toy interpreter implemented in Lisp."""
+import sys
+from lispfun.interpreter import standard_env
+from lispfun.run import load_eval, load_toy, toy_run_file, repl
+
+
+def main() -> None:
+    env = standard_env()
+    load_eval(env)
+    load_toy(env)
+    if len(sys.argv) > 1:
+        toy_run_file(sys.argv[1], env)
+    else:
+        repl(env)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_bootstrap.py`, `run_hosted.py` and `run_toy.py`
- document new runners in README and bootstrap docs
- update bootstrap docs to use the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779bc472d8832abb303ba6e2240342