### PR TITLE
Ensure run_toy starts toy REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ you wish to bootstrap:
 ```bash
 python run_bootstrap.py [file]   # pure Python interpreter
 python run_hosted.py [file]      # load evaluator.lisp and use eval2
-python run_toy.py [file]         # load evaluator and toy interpreter
+python run_toy.py [file]         # load evaluator and toy interpreter (toy REPL)
 ```
 
-Running without a file starts a REPL. `python -m lispfun` behaves like
-`run_hosted.py` but only loads the toy interpreter when executing a file.
-History support is enabled if the `readline` module is available.
+Running without a file starts a REPL. `run_bootstrap.py` and `run_hosted.py`
+launch the Python REPL, while `run_toy.py` starts the toy REPL written in Lisp.
+`python -m lispfun` behaves like `run_hosted.py` but only loads the toy
+interpreter when executing a file. History support is enabled if the `readline`
+module is available.
 
 ## Example Programs
 

--- a/run_toy.py
+++ b/run_toy.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 """Run the toy interpreter implemented in Lisp."""
 import sys
+import os
 from lispfun.interpreter import standard_env
-from lispfun.run import load_eval, load_toy, toy_run_file, repl
+from lispfun.run import load_eval, load_toy, toy_run_file
+
+TOY_REPL_FILE = os.path.join(os.path.dirname(__file__), "examples", "toy-repl.lisp")
 
 
 def main() -> None:
@@ -12,7 +15,7 @@ def main() -> None:
     if len(sys.argv) > 1:
         toy_run_file(sys.argv[1], env)
     else:
-        repl(env)
+        toy_run_file(TOY_REPL_FILE, env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- call into the toy REPL when running `run_toy.py` without a script
- document that `run_toy.py` launches the toy REPL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a6f98564832aa021d585a2cdf11b