### PR TITLE
Add loop macros to toy interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ LispFun is a small Lisp interpreter written in Python with an increasing amount 
   - `read-line` primitive for interactive input.
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
+  - Loop macros `while` and `for` in the toy interpreter.
 - Semicolon comments are recognized by the parser.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing and macros.
 - A comprehensive unit test suite including a `selftest.lisp` script executed by the evaluator.
@@ -56,6 +57,7 @@ Available scripts include:
 - `fibonacci.lisp` – compute Fibonacci numbers
 - `list-demo.lisp` – demonstrate list utilities
 - `macro-example.lisp` – use a simple `when` macro
+- `loop-demo.lisp` – illustrate `while` and `for` macros
 - `toy-interpreter.lisp` – illustrative Lisp interpreter written in Lisp.
   See [docs/toy_interpreter.md](docs/toy_interpreter.md) for usage.
 - `toy-runner.lisp` – load the toy interpreter and run all other examples.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -8,7 +8,10 @@ The toy interpreter demonstrates how a complete Lisp system can be built in Lisp
 
 `toy-interpreter.lisp` loads these pieces and exposes helper functions such as `run-file` and a small REPL.
 
-The evaluator supports `define-macro` so macros can be expanded when running code entirely in Lisp.
+The evaluator supports `define-macro` so macros can be expanded when running code entirely in Lisp.  Looping constructs are provided purely as macros:
+
+- `(while test expr)` – repeatedly evaluate `expr` while `test` is true.
+- `(for var start end expr)` – iterate `var` from `start` up to but not including `end` evaluating `expr` each time.
 
 Run the interpreter with:
 

--- a/examples/loop-demo.lisp
+++ b/examples/loop-demo.lisp
@@ -1,0 +1,8 @@
+(define i 0)
+(while (< i 3)
+  (begin
+    (print i)
+    (set! i (+ i 1))))
+(for j 0 5
+  (print (* j j)))
+

--- a/examples/toy-evaluator.lisp
+++ b/examples/toy-evaluator.lisp
@@ -97,6 +97,29 @@
   (lambda (x)
     (if x 0 1)))
 
+; Basic looping macros implemented without evaluator changes
+(define-macro while
+  (lambda (test body)
+    (list (quote begin)
+          (list (quote define) (quote while-loop)
+                (list (quote lambda) (quote ())
+                      (list (quote if) test
+                            (list (quote begin) body (list (quote while-loop)))
+                            0)))
+          (list (quote while-loop)))) )
+
+(define-macro for
+  (lambda (var start end body)
+    (list (quote begin)
+          (list (quote define) (quote for-loop)
+                (list (quote lambda) (list var)
+                      (list (quote if) (list (quote <) var end)
+                            (list (quote begin) body
+                                  (list (quote for-loop)
+                                        (list (quote +) var 1)))
+                            0)))
+          (list (quote for-loop) start))) )
+
 ; List access helpers used by the evaluator and parser
 (define cadr (lambda (lst) (car (cdr lst))))
 (define caddr (lambda (lst) (car (cdr (cdr lst)))))

--- a/examples/toy-runner.lisp
+++ b/examples/toy-runner.lisp
@@ -4,5 +4,6 @@
 (run-file "examples/factorial.lisp")
 (run-file "examples/fibonacci.lisp")
 (run-file "examples/list-demo.lisp")
+(run-file "examples/loop-demo.lisp")
 ; macro-example requires define-macro which isn't handled by the toy interpreter
 ; when imported directly via Python. It can be run manually if desired.

--- a/tests/test_lisp_files.py
+++ b/tests/test_lisp_files.py
@@ -24,6 +24,8 @@ SELFTEST_FILE = os.path.join(os.path.dirname(__file__), "lisp", "selftest.lisp")
 STRINGPARSE_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringparse.lisp")
 STRINGUTILS_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringutils.lisp")
 TOY_RUNNER_FILE = os.path.join(os.path.dirname(__file__), "..", "examples", "toy-runner.lisp")
+LOOP_DEMO_FILE = os.path.join(os.path.dirname(__file__), "..", "examples", "loop-demo.lisp")
+TOY_FILE = os.path.join(os.path.dirname(__file__), "..", "examples", "toy-interpreter.lisp")
 
 
 def run_file_with_eval(file_path):
@@ -44,6 +46,29 @@ def run_file_with_eval2(file_path):
     for exp in parse_multiple(evaluator_code):
         eval_lisp(exp, env)
     env['env'] = env
+    with open(file_path) as f:
+        code = f.read()
+    exprs = parse_multiple(code)
+    result = None
+    for exp in exprs:
+        program = f"(eval2 (quote {to_string(exp)}) env)"
+        result = eval_lisp(parse(program), env)
+    return result
+
+
+def run_file_with_eval2_toy(file_path):
+    """Run a file using eval2 after loading the toy interpreter."""
+    env = standard_env()
+    with open(EVAL_FILE) as f:
+        evaluator_code = f.read()
+    for exp in parse_multiple(evaluator_code):
+        eval_lisp(exp, env)
+    env["env"] = env
+    with open(TOY_FILE) as f:
+        toy_code = f.read()
+    for exp in parse_multiple(toy_code):
+        program = f"(eval2 (quote {to_string(exp)}) env)"
+        eval_lisp(parse(program), env)
     with open(file_path) as f:
         code = f.read()
     exprs = parse_multiple(code)
@@ -108,6 +133,12 @@ def test_stringutils_script():
 
 def test_toy_runner_script():
     # Running the toy interpreter and all example programs should succeed
-    assert run_file_with_eval2(TOY_RUNNER_FILE) is None
+    assert run_file_with_eval2(TOY_RUNNER_FILE) == 0
+
+
+def test_loop_demo_script():
+    # New example exercising while/for macros
+    assert run_file_with_eval2_toy(LOOP_DEMO_FILE) == 0
+
 
 


### PR DESCRIPTION
## Summary
- implement `while` and `for` macros in `examples/toy-evaluator.lisp`
- add `loop-demo.lisp` example exercising new macros and include in `toy-runner`
- document loop support in `docs/toy_interpreter.md` and mention in README
- extend tests to run the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aa1e36c4832a8fe8e747d6b7503f