### PR TITLE
Add loop macros to toy Lisp

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ LispFun is a small Lisp interpreter written in Python with an increasing amount 
   - `read-line` primitive for interactive input.
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
+  - Loop macros `while` and `for` allow simple iterative code in the toy interpreter.
 - Semicolon comments are recognized by the parser.
-- Example scripts demonstrate factorials, Fibonacci numbers, list processing and macros.
+- Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.
 - A comprehensive unit test suite including a `selftest.lisp` script executed by the evaluator.
 
 ## Documentation
@@ -60,6 +61,7 @@ Available scripts include:
 - `factorial.lisp` – recursive factorial calculation
 - `fibonacci.lisp` – compute Fibonacci numbers
 - `list-demo.lisp` – demonstrate list utilities
+- `loop-demo.lisp` – illustrate `while` and `for` macros
 - `macro-example.lisp` – use a simple `when` macro
 - `toy-interpreter.lisp` – illustrative Lisp interpreter written in Lisp.
   See [docs/toy_interpreter.md](docs/toy_interpreter.md) for usage.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -10,6 +10,19 @@ The toy interpreter demonstrates how a complete Lisp system can be built in Lisp
 
 The evaluator supports `define-macro` so macros can be expanded when running code entirely in Lisp.
 
+`toy-evaluator.lisp` also defines simple `while` and `for` macros so iterative
+loops can be written without modifying the evaluator.
+
+Example:
+
+```lisp
+(define n 3)
+(define total 0)
+(for i 1 n
+  (set! total (+ total i)))
+(print total) ; => 6
+```
+
 Run the interpreter with:
 
 ```bash

--- a/examples/loop-demo.lisp
+++ b/examples/loop-demo.lisp
@@ -1,0 +1,10 @@
+(define n 5)
+(define fac 1)
+(while (> n 1)
+  (begin
+    (set! fac (* fac n))
+    (set! n (- n 1))))
+(define sum 0)
+(for i 1 5
+  (set! sum (+ sum i)))
+(print (list fac sum))

--- a/lispfun/list_utils.lisp
+++ b/lispfun/list_utils.lisp
@@ -21,3 +21,9 @@
         (if (pred (car lst))
             (cons (car lst) (filter pred (cdr lst)))
             (filter pred (cdr lst))))) )
+
+(define append
+  (lambda (a b)
+    (if (null? a)
+        b
+        (cons (car a) (append (cdr a) b)))) )

--- a/tests/lisp/loops.lisp
+++ b/tests/lisp/loops.lisp
@@ -1,0 +1,10 @@
+(define n 5)
+(define fac 1)
+(while (> n 1)
+  (begin
+    (set! fac (* fac n))
+    (set! n (- n 1))))
+(define sum 0)
+(for i 1 5
+  (set! sum (+ sum i)))
+(list fac sum)

--- a/tests/test_toy_interpreter.py
+++ b/tests/test_toy_interpreter.py
@@ -6,6 +6,7 @@ from lispfun.run import load_eval, load_toy, toy_run_file
 
 
 BASIC_TEST = os.path.join(os.path.dirname(__file__), "lisp", "basic.lisp")
+LOOP_TEST = os.path.join(os.path.dirname(__file__), "lisp", "loops.lisp")
 
 
 def setup_env():
@@ -19,3 +20,9 @@ def test_toy_run_basic():
     env = setup_env()
     result = toy_run_file(BASIC_TEST, env)
     assert result == [6, 4, 5, 7, 1, 1, [2, 3], [0, 1, 2, 3], [1, 2]]
+
+
+def test_toy_run_loops():
+    env = setup_env()
+    result = toy_run_file(LOOP_TEST, env)
+    assert result == [120, 15]

--- a/toy/toy-evaluator.lisp
+++ b/toy/toy-evaluator.lisp
@@ -121,3 +121,21 @@
 (define run-file
   (lambda (path)
     (import path)))
+
+; Simple loop macros built entirely in Lisp
+(define-macro while
+  (lambda (test body)
+    (list (quote if) test
+          (list (quote begin)
+                body
+                (list (quote while) test body))
+          0)))
+
+(define-macro for
+  (lambda (var start end body)
+    (list (quote begin)
+          (list (quote define) var start)
+          (list (quote while) (list (quote <=) var end)
+                (list (quote begin)
+                      body
+                      (list (quote set!) var (list (quote +) var 1)))))) )

--- a/toy/toy-runner.lisp
+++ b/toy/toy-runner.lisp
@@ -4,5 +4,6 @@
 (run-file "examples/factorial.lisp")
 (run-file "examples/fibonacci.lisp")
 (run-file "examples/list-demo.lisp")
+(run-file "examples/loop-demo.lisp")
 ; macro-example requires define-macro which isn't handled by the toy interpreter
 ; when imported directly via Python. It can be run manually if desired.


### PR DESCRIPTION
## Summary
- implement `while` and `for` as macros in `toy-evaluator.lisp`
- add `append` helper to `list_utils.lisp`
- provide new example `loop-demo.lisp`
- run loop example in `toy-runner.lisp`
- document loop macros in `docs/toy_interpreter.md`
- mention loop support in README
- add tests for loops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877af51a9c8832ab348d4c0545ce69f