### PR TITLE
Document toy REPL limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ LispFun is a small Lisp interpreter written in Python with an increasing amount 
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
   - Loop macros `while` and `for` allow simple iterative code in the toy interpreter.
+  - The toy REPL currently lacks string literal support.
 - Semicolon comments are recognized by the parser.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.
 - A comprehensive unit test suite including a `selftest.lisp` script executed by the evaluator.

--- a/lispfun/interpreter.py
+++ b/lispfun/interpreter.py
@@ -42,6 +42,8 @@ def standard_env() -> Environment:
         'cons': lambda x, y: [x] + y,
         'list?': lambda x: isinstance(x, list),
         'symbol?': lambda x: isinstance(x, Symbol),
+        'number?': lambda x: isinstance(x, (int, float)),
+        'string?': lambda x: isinstance(x, str),
         'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
         'read-file': read_file,


### PR DESCRIPTION
## Summary
- add `number?` and `string?` primitives to the Python environment
- document that the toy REPL does not yet support string literals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b5657004832a85bb0bb5c5721117