### PR TITLE
Fix toy interpreter string handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ The repository now separates the main components for clarity:
   - `cond` form and `define-macro` for simple macros.
   - List utilities: `null?`, `length`, `map` and `filter`.
   - String helpers: `parse-string`, `string-for-each`, `build-string`.
+  - Predicates `number?` and `string?` for identifying literal types.
   - `read-line` primitive for interactive input.
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
   - Loop macros `while` and `for` allow simple iterative code in the toy interpreter.
-- Semicolon comments are recognized by the parser.
+  - Toy interpreter now parses string literals.
+  - Semicolon comments are recognized by the parser.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.
 - A comprehensive unit test suite including a `selftest.lisp` script executed by the evaluator.
 

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -6,12 +6,15 @@ The toy interpreter demonstrates how a complete Lisp system can be built in Lisp
 - `toy-parser.lisp` – builds lists and atoms from the token stream.
 - `toy-evaluator.lisp` – evaluates expressions using a simple environment.
 
-`toy-interpreter.lisp` loads these pieces and exposes helper functions such as `run-file` and a small REPL.
+`toy-interpreter.lisp` loads these pieces and exposes helper functions such as `run-file` and a small REPL. String literals are recognized so `(print "hi")` works as expected.
 
 The evaluator supports `define-macro` so macros can be expanded when running code entirely in Lisp.
 
 `toy-evaluator.lisp` also defines simple `while` and `for` macros so iterative
 loops can be written without modifying the evaluator.
+
+Basic predicates `number?` and `string?` are available and the tokenizer handles
+quoted strings.
 
 Example:
 

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -42,6 +42,8 @@ def standard_env() -> Environment:
         'cons': lambda x, y: [x] + y,
         'list?': lambda x: isinstance(x, list),
         'symbol?': lambda x: isinstance(x, Symbol),
+        'number?': lambda x: isinstance(x, (int, float)),
+        'string?': lambda x: isinstance(x, str),
         'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
         'read-file': read_file,

--- a/tests/lisp/toy-strings.lisp
+++ b/tests/lisp/toy-strings.lisp
@@ -1,0 +1,1 @@
+(list (string? "abc") (number? 42))

--- a/tests/test_toy_interpreter.py
+++ b/tests/test_toy_interpreter.py
@@ -7,6 +7,7 @@ from lispfun.run import load_eval, load_toy, toy_run_file
 
 BASIC_TEST = os.path.join(os.path.dirname(__file__), "lisp", "basic.lisp")
 LOOP_TEST = os.path.join(os.path.dirname(__file__), "lisp", "loops.lisp")
+STRING_TEST = os.path.join(os.path.dirname(__file__), "lisp", "toy-strings.lisp")
 
 
 def setup_env():
@@ -26,3 +27,9 @@ def test_toy_run_loops():
     env = setup_env()
     result = toy_run_file(LOOP_TEST, env)
     assert result == [120, 15]
+
+
+def test_toy_run_strings():
+    env = setup_env()
+    result = toy_run_file(STRING_TEST, env)
+    assert result == [True, True]

--- a/toy/toy-evaluator.lisp
+++ b/toy/toy-evaluator.lisp
@@ -50,7 +50,7 @@
                (let ((args (map (lambda (e) (eval-expr e env)) (cdr x))))
                  (apply-closure proc args))))))
       (else
-       (if (number? x)
+       (if (or (number? x) (string? x))
            x
            (lookup env x))))))
 )
@@ -76,6 +76,8 @@
     (list "car" car)
     (list "cdr" cdr)
     (list "cons" cons)
+    (list "number?" number?)
+    (list "string?" string?)
     (list "print" print)
     (list "null?" null?)
     (list "length" length)

--- a/toy/toy-tokenizer.lisp
+++ b/toy/toy-tokenizer.lisp
@@ -45,11 +45,24 @@
         (if (and (< k len)
                  (not (whitespace? (string-slice text k (+ k 1))))
                  (not (= (string-slice text k (+ k 1)) "("))
-                 (not (= (string-slice text k (+ k 1)) ")")))
+                 (not (= (string-slice text k (+ k 1)) ")"))
+                 (not (= (string-slice text k (+ k 1)) (chr 34))))
             (loop (+ k 1))
             k)))
     (set! j (loop j))
     (list j (string-slice text idx j))))
+
+; Read a string token starting at index idx
+(define read-string
+  (lambda (text idx len)
+    (define j (+ idx 1))
+    (define loop
+      (lambda (k acc)
+        (if (or (>= k len) (= (string-slice text k (+ k 1)) (chr 34)))
+            (list (+ k 1) (make-string acc))
+            (loop (+ k 1)
+                  (string-concat acc (string-slice text k (+ k 1)))))))
+    (loop j "")))
 
 ; Tokenize a program string
 (define tokenize
@@ -64,11 +77,15 @@
                 ((whitespace? c) (iter (+ i 1) acc))
                 ((= c "(") (iter (+ i 1) (cons "(" acc)))
                 ((= c ")") (iter (+ i 1) (cons ")" acc)))
+                ((= c (chr 34))
+                 (let ((res (read-string text i len)))
+                   (iter (car res) (cons (cadr res) acc))))
                 ((digit? c)
                  (let ((res (read-number text i len)))
                    (iter (car res) (cons (cadr res) acc))))
                 (else
                  (let ((res (read-symbol text i len)))
                    (iter (car res) (cons (cadr res) acc))))))))
-    (iter 0 (quote ()))) )
+    (iter 0 (quote ())))
+)
 )


### PR DESCRIPTION
## Summary
- add `number?` and `string?` predicates to the Python standard environment
- extend toy evaluator to use the new predicates and export them
- implement string literal support in the Lisp tokenizer
- document string support in README and toy interpreter docs
- add tests covering string handling in the toy interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877bab6e2dc832a9eb880350d341d24