### PR TITLE
Add CLI test for run_toy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ you wish to bootstrap:
 ```
 Each script is executable so you can invoke it directly from the shell.
 
+You can also pipe a short snippet into the toy interpreter by passing
+`/dev/stdin` as the file path:
+
+```bash
+echo '(print "hi")' | ./run_toy.py /dev/stdin
+```
+
 Running without a file starts a REPL. `run_bootstrap.py` and `run_hosted.py`
 launch the Python REPL, while `run_toy.py` starts the toy REPL written in Lisp.
 `python -m lispfun` behaves like `run_hosted.py` but only loads the toy

--- a/toy/tests/test_run_toy_cli.py
+++ b/toy/tests/test_run_toy_cli.py
@@ -1,0 +1,12 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def test_run_toy_from_stdin():
+    root = Path(__file__).resolve().parents[2]
+    run_toy = root / "run_toy.py"
+    cmd = [sys.executable, str(run_toy), "/dev/stdin"]
+    proc = subprocess.run(cmd, input='(print "Hello...")', text=True, capture_output=True, check=True)
+    assert proc.stdout.strip() == "Hello..."


### PR DESCRIPTION
## Summary
- document how to pipe snippets into `run_toy.py`
- add a test ensuring piping to `/dev/stdin` works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c5a82384832a838a13994ee6a2b6