### PR TITLE
Improve Lisp tests runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ python -m lispfun toy/toy-runner.lisp
 ```bash
 python -m lispfun toy/toy-repl.lisp
 ```
-- `run-tests.lisp` – runs all Lisp tests from the interpreter-specific `tests/lisp` folders; run it with `python -m lispfun examples/run-tests.lisp`
+- `run-tests.lisp` – executes all Lisp-based unit tests across the bootstrap, hosted and toy interpreters. Each file reports `PASS` or `FAIL` similar to a Python test runner. Run it with `python -m lispfun examples/run-tests.lisp`
 
 
 ## Work Remaining

--- a/examples/run-tests.lisp
+++ b/examples/run-tests.lisp
@@ -1,17 +1,50 @@
 ; Run all Lisp tests using the built-in import facility.
-; Define a helper that announces each file before importing it so
-; Tests reside in interpreter-specific directories under lispfun/<interpreter>/tests/lisp.
-; it's clear which tests execute.
+; Output PASS/FAIL lines similar to a unit test runner.
+
+(define failures 0)
+
+(define equal?
+  (lambda (a b)
+    (if (list? a)
+        (if (list? b)
+            (if (= (length a) (length b))
+                (if (null? a)
+                    1
+                    (if (equal? (car a) (car b))
+                        (equal? (cdr a) (cdr b))
+                        0))
+                0)
+            0)
+        (= a b))))
 
 (define run-test
-  (lambda (file)
-    (begin
-      (print (string-concat "Running " file))
-      (print (import file)))))
+  (lambda (file expected)
+    (let ((result (import file)))
+      (if (equal? result expected)
+          (print (string-concat file " ... PASS"))
+          (begin
+            (set! failures (+ failures 1))
+            (print (string-concat file " ... FAIL"))
+            (print "expected:")
+            (print expected)
+            (print "got:")
+            (print result))))))
 
-(run-test "lispfun/bootstrap/tests/lisp/bootstrap.lisp")
-(run-test "lispfun/hosted/tests/lisp/basic.lisp")
-(run-test "lispfun/bootstrap/tests/lisp/import_main.lisp")
-(run-test "lispfun/hosted/tests/lisp/selftest.lisp")
-(run-test "lispfun/hosted/tests/lisp/stringparse.lisp")
-(run-test "lispfun/hosted/tests/lisp/stringutils.lisp")
+(run-test "lispfun/bootstrap/tests/lisp/bootstrap.lisp"
+          (quote (6 4 7 1 (1 2))))
+(run-test "lispfun/hosted/tests/lisp/basic.lisp"
+          (quote (6 4 5 7 1 1 (2 3) (0 1 2 3) (1 2))))
+(run-test "lispfun/bootstrap/tests/lisp/import_main.lisp" 42)
+(run-test "lispfun/hosted/tests/lisp/selftest.lisp" 1)
+(run-test "lispfun/hosted/tests/lisp/stringparse.lisp" 1)
+(run-test "lispfun/hosted/tests/lisp/stringutils.lisp" 1)
+(import "toy/toy-interpreter.lisp")
+(run-test "toy/tests/lisp/loops.lisp" (quote (120 15)))
+(define expected-strings (list (string? "abc") (number? 42)))
+(run-test "toy/tests/lisp/toy-strings.lisp" expected-strings)
+
+(if (= failures 0)
+    (print "All Lisp tests passed.")
+    (begin
+      (print "Some Lisp tests failed.")
+      (print failures)))


### PR DESCRIPTION
## Summary
- enhance `examples/run-tests.lisp` so it checks expected results and runs the toy tests
- document the new behaviour in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877df1d1e7c832aa53f2a96a45e2400