### PR TITLE
Separate Lisp test runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,21 @@ python -m lispfun toy/toy-runner.lisp
 ```bash
 python -m lispfun toy/toy-repl.lisp
 ```
-- `run-tests.lisp` – executes all Lisp-based unit tests across the bootstrap, hosted and toy interpreters. Each file reports `PASS` or `FAIL` similar to a Python test runner. Run it with `python -m lispfun examples/run-tests.lisp`
+- `bootstrap-tests.lisp` – run Lisp unit tests for the bootstrap interpreter:
+
+```bash
+./run_bootstrap.py examples/bootstrap-tests.lisp
+```
+- `hosted-tests.lisp` – run tests using the self-hosted evaluator:
+
+```bash
+python -m lispfun examples/hosted-tests.lisp
+```
+- `toy-tests.lisp` – run tests for the toy interpreter:
+
+```bash
+./run_toy.py examples/toy-tests.lisp
+```
 
 
 ## Work Remaining

--- a/examples/bootstrap-tests.lisp
+++ b/examples/bootstrap-tests.lisp
@@ -1,0 +1,40 @@
+; Run Lisp unit tests for the bootstrap interpreter.
+
+(define failures 0)
+
+(define equal?
+  (lambda (a b)
+    (if (list? a)
+        (if (list? b)
+            (if (= (length a) (length b))
+                (if (null? a)
+                    1
+                    (if (equal? (car a) (car b))
+                        (equal? (cdr a) (cdr b))
+                        0))
+                0)
+            0)
+        (= a b))))
+
+(define run-test
+  (lambda (file expected)
+    (let ((result (import file)))
+      (if (equal? result expected)
+          (print (string-concat file " ... PASS"))
+          (begin
+            (set! failures (+ failures 1))
+            (print (string-concat file " ... FAIL"))
+            (print "expected:")
+            (print expected)
+            (print "got:")
+            (print result))))))
+
+(run-test "lispfun/bootstrap/tests/lisp/bootstrap.lisp"
+          (quote (6 4 7 1 (1 2))))
+(run-test "lispfun/bootstrap/tests/lisp/import_main.lisp" 42)
+
+(if (= failures 0)
+    (print "All bootstrap tests passed.")
+    (begin
+      (print "Some bootstrap tests failed.")
+      (print failures)))

--- a/examples/hosted-tests.lisp
+++ b/examples/hosted-tests.lisp
@@ -1,0 +1,42 @@
+; Run Lisp unit tests for the hosted evaluator.
+
+(define failures 0)
+
+(define equal?
+  (lambda (a b)
+    (if (list? a)
+        (if (list? b)
+            (if (= (length a) (length b))
+                (if (null? a)
+                    1
+                    (if (equal? (car a) (car b))
+                        (equal? (cdr a) (cdr b))
+                        0))
+                0)
+            0)
+        (= a b))))
+
+(define run-test
+  (lambda (file expected)
+    (let ((result (import file)))
+      (if (equal? result expected)
+          (print (string-concat file " ... PASS"))
+          (begin
+            (set! failures (+ failures 1))
+            (print (string-concat file " ... FAIL"))
+            (print "expected:")
+            (print expected)
+            (print "got:")
+            (print result))))))
+
+(run-test "lispfun/hosted/tests/lisp/basic.lisp"
+          (quote (6 4 5 7 1 1 (2 3) (0 1 2 3) (1 2))))
+(run-test "lispfun/hosted/tests/lisp/selftest.lisp" 1)
+(run-test "lispfun/hosted/tests/lisp/stringparse.lisp" 1)
+(run-test "lispfun/hosted/tests/lisp/stringutils.lisp" 1)
+
+(if (= failures 0)
+    (print "All hosted tests passed.")
+    (begin
+      (print "Some hosted tests failed.")
+      (print failures)))

--- a/examples/toy-tests.lisp
+++ b/examples/toy-tests.lisp
@@ -1,0 +1,40 @@
+; Run Lisp unit tests for the toy interpreter.
+
+(define failures 0)
+
+(define equal?
+  (lambda (a b)
+    (if (list? a)
+        (if (list? b)
+            (if (= (length a) (length b))
+                (if (null? a)
+                    1
+                    (if (equal? (car a) (car b))
+                        (equal? (cdr a) (cdr b))
+                        0))
+                0)
+            0)
+        (= a b))))
+
+(define run-test
+  (lambda (file expected)
+    (let ((result (run-file file))) ; run-file defined by toy interpreter
+      (if (equal? result expected)
+          (print (string-concat file " ... PASS"))
+          (begin
+            (set! failures (+ failures 1))
+            (print (string-concat file " ... FAIL"))
+            (print "expected:")
+            (print expected)
+            (print "got:")
+            (print result))))))
+
+(run-test "toy/tests/lisp/loops.lisp" (quote (120 15)))
+(define expected-strings (list (string? "abc") (number? 42)))
+(run-test "toy/tests/lisp/toy-strings.lisp" expected-strings)
+
+(if (= failures 0)
+    (print "All toy tests passed.")
+    (begin
+      (print "Some toy tests failed.")
+      (print failures)))

--- a/lispfun/hosted/tests/test_run_tests_script.py
+++ b/lispfun/hosted/tests/test_run_tests_script.py
@@ -17,7 +17,14 @@ except ImportError:  # pragma: no cover - parser not implemented yet
     parse_lisp = parse
 
 EVAL_FILE = os.path.join(os.path.dirname(__file__), "..", "evaluator.lisp")
-RUN_TESTS_FILE = os.path.join(os.path.dirname(__file__), "..", "..", "..", "examples", "run-tests.lisp")
+RUN_TESTS_FILE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "examples",
+    "hosted-tests.lisp",
+)
 
 
 def run_file_with_eval2(file_path):


### PR DESCRIPTION
## Summary
- add three independent test runner scripts
- document running each set of tests
- update hosted test to use the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e29516d8832ab322554276add3b4