### PR TITLE
Add trap-error primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The repository now separates the main components for clarity:
   - Semicolon comments are recognized by the parser.
   - Command line arguments after the script name are available as the `args` list.
   - `(require "file")` loads Lisp files once to support a basic module system.
+  - `(error "msg")` raises an exception and `(trap-error thunk handler)`
+    invokes `handler` with the message if evaluating `thunk` fails.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.
 - A comprehensive unit test suite with Lisp programs stored alongside each interpreter.
 

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -17,6 +17,8 @@ Basic predicates `number?` and `string?` are available and the tokenizer handles
 quoted strings.
 The `(require "file.lisp")` form loads a Lisp file only once so modules aren't
 imported multiple times.
+`(error "msg")` raises an exception and `(trap-error thunk handler)` can be
+used to recover from runtime errors.
 
 Example:
 

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -16,6 +16,13 @@ def _read_line(prompt: str = "") -> str:
     except EOFError:
         return ""
 
+# helpers for error handling
+def _trap_error(thunk, handler):
+    try:
+        return thunk()
+    except Exception as e:
+        return handler(str(e))
+
 from .parser import (
     Symbol,
     String,
@@ -43,6 +50,9 @@ def standard_env() -> Environment:
         'max': max,
         'min': min,
         'print': print,
+        # error handling primitives
+        'error': lambda msg: (_ for _ in ()).throw(RuntimeError(str(msg))),
+        'trap-error': lambda thunk, handler: _trap_error(thunk, handler),
         # list utilities
         'list': lambda *x: list(x),
         'car': lambda x: x[0],

--- a/toy/tests/test_toy_interpreter.py
+++ b/toy/tests/test_toy_interpreter.py
@@ -2,7 +2,8 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from lispfun.interpreter import standard_env
-from lispfun.run import load_eval, load_toy, toy_run_file
+from lispfun.run import load_eval, load_toy, toy_run_file, eval_with_eval2
+from lispfun.interpreter import parse
 
 
 BASIC_TEST = os.path.join(os.path.dirname(__file__), "..", "..", "lispfun", "hosted", "tests", "lisp", "basic.lisp")
@@ -40,4 +41,11 @@ def test_toy_require_module():
     env = setup_env()
     result = toy_run_file(REQUIRE_TEST, env)
     assert result == 1
+
+
+def test_trap_error():
+    env = setup_env()
+    exp = parse('(trap-error (lambda () (error "fail")) (lambda (m) m))')
+    result = eval_with_eval2(exp, env)
+    assert result == 'fail'
 


### PR DESCRIPTION
## Summary
- provide simple exception handling in the bootstrap environment
- expose `(error)` and `(trap-error)` to Lisp code
- describe the new primitives in the docs and README
- test exception handling through the toy interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e54a975c832aa8bb6e19a460867a