### PR TITLE
Add toy REPL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,37 @@ cat <<'EOF' | ./run_toy.py /dev/stdin
 EOF
 ```
 
-To send input to the toy REPL itself, run the REPL script and pipe a
-string or here-document into standard input. The REPL now exits cleanly
+You can also feed a single expression to the toy interpreter by piping it
+directly into `run_toy.py`. The program will execute the input and exit
 when it reaches end-of-file:
 
 ```bash
-./run_toy.py toy/toy-repl.lisp <<< '(print "hi")'
+./run_toy.py <<< '(print "hi")'
 ```
 
-When running without a file, `run_toy.py` starts a minimal REPL that only
-prints the result of side-effecting operations like `print`.
+A small helper script `run_hi.sh` demonstrates the same idea (no `toy>` prompt
+because it is not running the interactive REPL):
+
+```bash
+./run_hi.sh
+# => hi
+```
+
+When launched without a file and an interactive terminal is attached,
+`run_toy.py` starts the toy REPL. If standard input is redirected it
+executes the provided code instead of starting the REPL.  A quick REPL
+session looks like this:
+
+```bash
+$ ./run_toy.py
+toy> (print "hi")
+hi
+toy>
+```
 
 Running without a file starts a REPL. `run_bootstrap.py` and `run_hosted.py`
-launch the Python REPL, while `run_toy.py` starts the toy REPL written in Lisp.
+launch the Python REPL, while `run_toy.py` starts a REPL for the toy
+interpreter.
 `python -m lispfun` behaves like `run_hosted.py` but only loads the toy
 interpreter when executing a file. History support is enabled if the `readline`
 module is available.

--- a/run_hi.sh
+++ b/run_hi.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Simple script to demonstrate piping a single expression into run_toy.py
+# Prints "hi" if everything works correctly.
+
+SCRIPT_DIR="$(dirname "$0")"
+
+"$SCRIPT_DIR"/run_toy.py <<< '(print "hi")'

--- a/run_toy.py
+++ b/run_toy.py
@@ -2,10 +2,34 @@
 """Run the toy interpreter implemented in Lisp."""
 import sys
 import os
-from lispfun.bootstrap.interpreter import standard_env
-from lispfun.run import load_eval, load_toy, toy_run_file
+from lispfun.bootstrap.interpreter import (
+    standard_env,
+    parse,
+    to_string,
+    eval_lisp,
+)
+from lispfun.run import load_eval, load_toy, toy_run_file, eval_with_eval2
 
 TOY_REPL_FILE = os.path.join(os.path.dirname(__file__), "toy", "toy-repl.lisp")
+
+
+def python_toy_repl(env) -> None:
+    """Interactive REPL implemented in Python using the toy interpreter."""
+    while True:
+        try:
+            line = input("toy> ")
+        except EOFError:
+            print()
+            break
+        if line in {"", "exit"}:
+            break
+        try:
+            expr = parse(line)
+            result = eval_with_eval2(expr, env)
+            if result is not None:
+                print(to_string(result))
+        except Exception as exc:  # pragma: no cover - exercise REPL manually
+            print(f"Error: {exc}")
 
 
 def main() -> None:
@@ -19,7 +43,7 @@ def main() -> None:
         toy_run_file("/dev/stdin", env)
     else:
         env["args"] = []
-        toy_run_file(TOY_REPL_FILE, env)
+        python_toy_repl(env)
 
 
 if __name__ == "__main__":

--- a/toy/tests/test_toy_repl_interactive.py
+++ b/toy/tests/test_toy_repl_interactive.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pty
+import subprocess
+from pathlib import Path
+
+
+def run_interactive(expr: str) -> str:
+    root = Path(__file__).resolve().parents[2]
+    cmd = [sys.executable, str(root / 'run_toy.py')]
+    master_fd, slave_fd = pty.openpty()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    os.close(slave_fd)
+
+    out = ''
+    while 'toy>' not in out:
+        out += os.read(master_fd, 1024).decode()
+
+    os.write(master_fd, (expr + '\nexit\n').encode())
+
+    while True:
+        try:
+            chunk = os.read(master_fd, 1024)
+        except OSError:
+            break
+        if not chunk:
+            break
+        out += chunk.decode()
+    proc.wait(timeout=5)
+    os.close(master_fd)
+    return out
+
+
+def test_toy_repl_interactive_prints_hi():
+    output = run_interactive('(print "hi")')
+    assert 'hi' in output


### PR DESCRIPTION
## Summary
- clarify that `run_hi.sh` isn't the REPL
- show a short interactive REPL transcript in the README
- implement Python version of the toy REPL so interactive usage works
- add a test that drives the REPL via a pty

## Testing
- `pytest -q`
- `./run_hi.sh`


------
https://chatgpt.com/codex/tasks/task_e_6877e435d9b0832a9f8a0e2c3e8ad76c