### PR TITLE
Test CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ only supports programs that work with the Python evaluator so it fails on
 the hosted and toy example tests. `run_hosted.py` adds the self-hosted
 evaluator and runs both the bootstrap and hosted tests, while `run_toy.py`
 runs them all. The new tests under `examples/tests` exercise this behaviour.
-You can also run `./run_example_tests.sh` to try each interpreter on the example test suites.
+Run `./run_example_tests.sh` from the repository root to try each interpreter on the example test suites.
 
 
 ## Work Remaining

--- a/README.md
+++ b/README.md
@@ -126,13 +126,20 @@ python -m lispfun toy/toy-repl.lisp
 - `hosted-tests.lisp` – run tests using the self-hosted evaluator:
 
 ```bash
-python -m lispfun examples/hosted-tests.lisp
+./run_hosted.py examples/hosted-tests.lisp
 ```
 - `toy-tests.lisp` – run tests for the toy interpreter:
 
 ```bash
 ./run_toy.py examples/toy-tests.lisp
 ```
+
+The helper scripts load progressively more Lisp code. `run_bootstrap.py`
+only supports programs that work with the Python evaluator so it fails on
+the hosted and toy example tests. `run_hosted.py` adds the self-hosted
+evaluator and runs both the bootstrap and hosted tests, while `run_toy.py`
+runs them all. The new tests under `examples/tests` exercise this behaviour.
+You can also run `./run_example_tests.sh` to try each interpreter on the example test suites.
 
 
 ## Work Remaining

--- a/examples/tests/test_cli_examples.py
+++ b/examples/tests/test_cli_examples.py
@@ -1,0 +1,43 @@
+import sys
+import subprocess
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+run_bootstrap = root / 'run_bootstrap.py'
+run_hosted = root / 'run_hosted.py'
+run_toy = root / 'run_toy.py'
+bootstrap_tests = root / 'examples' / 'bootstrap-tests.lisp'
+hosted_tests = root / 'examples' / 'hosted-tests.lisp'
+toy_tests = root / 'examples' / 'toy-tests.lisp'
+
+
+def run(cmd):
+    return subprocess.run([sys.executable, str(cmd[0]), str(cmd[1])], capture_output=True)
+
+
+def test_bootstrap_examples():
+    proc = run([run_bootstrap, bootstrap_tests])
+    assert proc.returncode == 0
+    proc = run([run_bootstrap, hosted_tests])
+    assert proc.returncode != 0
+    proc = run([run_bootstrap, toy_tests])
+    assert proc.returncode != 0
+
+
+def test_hosted_examples():
+    proc = run([run_hosted, bootstrap_tests])
+    assert proc.returncode == 0
+    proc = run([run_hosted, hosted_tests])
+    assert proc.returncode == 0
+    proc = run([run_hosted, toy_tests])
+    assert proc.returncode != 0
+
+
+def test_toy_examples():
+    proc = run([run_toy, bootstrap_tests])
+    assert proc.returncode == 0
+    proc = run([run_toy, hosted_tests])
+    assert proc.returncode == 0
+    proc = run([run_toy, toy_tests])
+    assert proc.returncode == 0
+

--- a/examples/tests/test_cli_examples.py
+++ b/examples/tests/test_cli_examples.py
@@ -9,6 +9,7 @@ run_toy = root / 'run_toy.py'
 bootstrap_tests = root / 'examples' / 'bootstrap-tests.lisp'
 hosted_tests = root / 'examples' / 'hosted-tests.lisp'
 toy_tests = root / 'examples' / 'toy-tests.lisp'
+run_script = root / 'run_example_tests.sh'
 
 
 def run(cmd):
@@ -39,5 +40,10 @@ def test_toy_examples():
     proc = run([run_toy, hosted_tests])
     assert proc.returncode == 0
     proc = run([run_toy, toy_tests])
+    assert proc.returncode == 0
+
+
+def test_run_example_tests_script():
+    proc = subprocess.run(['bash', str(run_script)], capture_output=True)
     assert proc.returncode == 0
 

--- a/run_example_tests.sh
+++ b/run_example_tests.sh
@@ -8,14 +8,14 @@
 set -e
 cd "$(dirname "$0")"
 
-python ./run_bootstrap.py examples/bootstrap-tests.lisp
-python ./run_bootstrap.py examples/hosted-tests.lisp || true
-python ./run_bootstrap.py examples/toy-tests.lisp || true
+./run_bootstrap.py examples/bootstrap-tests.lisp
+./run_bootstrap.py examples/hosted-tests.lisp || true
+./run_bootstrap.py examples/toy-tests.lisp || true
 
-python ./run_hosted.py examples/bootstrap-tests.lisp
-python ./run_hosted.py examples/hosted-tests.lisp
-python ./run_hosted.py examples/toy-tests.lisp || true
+./run_hosted.py examples/bootstrap-tests.lisp
+./run_hosted.py examples/hosted-tests.lisp
+./run_hosted.py examples/toy-tests.lisp || true
 
-python ./run_toy.py examples/bootstrap-tests.lisp
-python ./run_toy.py examples/hosted-tests.lisp
-python ./run_toy.py examples/toy-tests.lisp
+./run_toy.py examples/bootstrap-tests.lisp
+./run_toy.py examples/hosted-tests.lisp
+./run_toy.py examples/toy-tests.lisp

--- a/run_example_tests.sh
+++ b/run_example_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run example test suites with each interpreter.
+# Expected results:
+# - run_bootstrap.py passes bootstrap tests but fails the others
+# - run_hosted.py runs bootstrap and hosted tests but fails toy tests
+# - run_toy.py runs all tests
+
+set -e
+cd "$(dirname "$0")"
+
+python ./run_bootstrap.py examples/bootstrap-tests.lisp
+python ./run_bootstrap.py examples/hosted-tests.lisp || true
+python ./run_bootstrap.py examples/toy-tests.lisp || true
+
+python ./run_hosted.py examples/bootstrap-tests.lisp
+python ./run_hosted.py examples/hosted-tests.lisp
+python ./run_hosted.py examples/toy-tests.lisp || true
+
+python ./run_toy.py examples/bootstrap-tests.lisp
+python ./run_toy.py examples/hosted-tests.lisp
+python ./run_toy.py examples/toy-tests.lisp


### PR DESCRIPTION
## Summary
- add CLI example tests to ensure each run_* script works on the expected example programs
- document how the helper scripts differ in README
- provide run_example_tests.sh convenience script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f6aa158c832a88d2edf8029c04fa