### PR TITLE
Use Lisp-based toy REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ because it is not running the interactive REPL):
 ```
 
 When launched without a file and an interactive terminal is attached,
-`run_toy.py` starts the toy REPL. If standard input is redirected it
+`run_toy.py` starts the toy REPL implemented in Lisp. If standard input is redirected it
 executes the provided code instead of starting the REPL.  A quick REPL
 session looks like this:
 
@@ -94,8 +94,10 @@ toy>
 ```
 
 Running without a file starts a REPL. `run_bootstrap.py` and `run_hosted.py`
-launch the Python REPL, while `run_toy.py` starts a REPL for the toy
-interpreter.
+launch the Python REPL, while `run_toy.py` starts a REPL executed by the toy
+interpreter itself. The previous Python implementation of the REPL is still
+available as the `python_toy_repl` function in `run_toy.py` for debugging or
+experimentation.
 `python -m lispfun` behaves like `run_hosted.py` but only loads the toy
 interpreter when executing a file. History support is enabled if the `readline`
 module is available.

--- a/run_toy.py
+++ b/run_toy.py
@@ -13,6 +13,8 @@ from lispfun.run import load_eval, load_toy, toy_run_file, eval_with_eval2
 TOY_REPL_FILE = os.path.join(os.path.dirname(__file__), "toy", "toy-repl.lisp")
 
 
+
+
 def python_toy_repl(env) -> None:
     """Interactive REPL implemented in Python using the toy interpreter."""
     while True:
@@ -32,6 +34,11 @@ def python_toy_repl(env) -> None:
             print(f"Error: {exc}")
 
 
+def lisp_toy_repl(env) -> None:
+    """Run the toy REPL implemented entirely in Lisp."""
+    toy_run_file(TOY_REPL_FILE, env)
+
+
 def main() -> None:
     env = standard_env()
     load_eval(env)
@@ -43,7 +50,7 @@ def main() -> None:
         toy_run_file("/dev/stdin", env)
     else:
         env["args"] = []
-        python_toy_repl(env)
+        lisp_toy_repl(env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run `run_toy.py` using the REPL implemented in `toy/toy-repl.lisp`
- keep `python_toy_repl` helper for debugging
- document `python_toy_repl` in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f87ba7cc832a8739454b527f7d5b