### PR TITLE
Fix Lisp REPL output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The repository now separates the main components for clarity:
   - String helpers: `parse-string`, `string-for-each`, `build-string`.
   - Predicates `number?` and `string?` for identifying literal types.
   - `read-line` primitive for interactive input.
+  - Toy REPL prints evaluation results and accepts `'bye` as a shortcut to exit.
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
   - Loop macros `while` and `for` allow simple iterative code in the toy interpreter.

--- a/toy/toy-repl.lisp
+++ b/toy/toy-repl.lisp
@@ -4,10 +4,13 @@
 (define toy-repl
   (lambda ()
     (define line (read-line "toy> "))
-    (if (or (= line "exit") (= line ""))
-        'bye
-        (begin
-          (eval-string line)
-          (toy-repl)))))
+    (cond
+      ((or (= line "exit") (= line "") (= line "'bye"))
+       (print "bye")
+       'bye)
+      (else
+       (let ((result (eval-string line)))
+         (if result (print result)))
+       (toy-repl)))))
 
 (toy-repl)


### PR DESCRIPTION
## Summary
- print results in the toy Lisp REPL
- allow `'bye` to exit the Lisp REPL
- document REPL improvement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fd380de4832a902e50bbc8240dac