### PR TITLE
Introduce kernel_env for minimal bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The repository now separates the main components for clarity:
 
 ## Completed Features
 
-- **Python bootstrap interpreter** with a REPL, basic arithmetic, variables and functions. The environment now provides built-in list utilities `null?`, `length`, `map` and `filter`.
+- **Python bootstrap interpreter** with a REPL, basic arithmetic, variables and functions. A new `kernel_env` exposes only the minimal primitives used for bootstrapping. The full environment still provides list utilities `null?`, `length`, `map` and `filter`.
 - **Self-hosted evaluator** written in Lisp loaded by `run_hosted.py` via `(import ...)`.
 - Lisp features implemented in Lisp:
   - `cond` form and `define-macro` for simple macros.

--- a/docs/bootstrap_interpreter.md
+++ b/docs/bootstrap_interpreter.md
@@ -1,6 +1,6 @@
 # Python Bootstrap Interpreter
 
-The bootstrap interpreter in `interpreter.py` is the initial Python implementation of LispFun. It provides a REPL and basic evaluation of arithmetic, variables and functions. The standard environment exposes list and string helpers, `import` for loading Lisp files and primitives needed by the Lisp evaluator.  It now also includes simple list utilities like `null?`, `length`, `map` and `filter` so example programs run without additional modules.
+The bootstrap interpreter in `interpreter.py` is the initial Python implementation of LispFun. It provides a REPL and basic evaluation of arithmetic, variables and functions. A new `kernel_env` function returns only the primitives required for bootstrapping. The standard environment builds on top of this, exposing list and string helpers, `import` for loading Lisp files and other conveniences. It still includes simple list utilities like `null?`, `length`, `map` and `filter` so example programs run without additional modules.
 
 Run the interpreter directly with:
 

--- a/lispfun/bootstrap/__init__.py
+++ b/lispfun/bootstrap/__init__.py
@@ -4,6 +4,6 @@ from .env import Environment
 from .parser import Symbol, String, ListType
 __all__ = [
     'parse', 'parse_multiple', 'to_string',
-    'eval_lisp', 'standard_env',
+    'eval_lisp', 'kernel_env', 'standard_env',
     'Environment', 'Symbol', 'String', 'ListType'
 ]

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -34,37 +34,44 @@ from .parser import (
 from .env import Environment
 
 
-def standard_env() -> Environment:
+def kernel_env() -> Environment:
+    """Return the minimal environment used during bootstrapping."""
     env = Environment()
     env.update({
-        "+": lambda *x: sum(x),
-        "-": lambda x, *rest: x - sum(rest) if rest else -x,
-        "*": lambda *x: reduce(op.mul, x, 1),
+        '+': lambda *x: sum(x),
+        '-': lambda x, *rest: x - sum(rest) if rest else -x,
+        '*': lambda *x: reduce(op.mul, x, 1),
         '/': lambda x, y: x / y,
         '>': op.gt,
         '<': op.lt,
         '>=': op.ge,
         '<=': op.le,
         '=': op.eq,
-        'abs': abs,
-        'max': max,
-        'min': min,
         'print': print,
-        # error handling primitives
-        'error': lambda msg: (_ for _ in ()).throw(RuntimeError(str(msg))),
-        'trap-error': lambda thunk, handler: _trap_error(thunk, handler),
-        # list utilities
         'list': lambda *x: list(x),
         'car': lambda x: x[0],
         'cdr': lambda x: x[1:],
         'cons': lambda x, y: [x] + y,
+        'apply': lambda f, args: f(*args),
+    })
+    return env
+
+
+def standard_env() -> Environment:
+    env = kernel_env()
+    env.update({
+        'abs': abs,
+        'max': max,
+        'min': min,
+        # error handling primitives
+        'error': lambda msg: (_ for _ in ()).throw(RuntimeError(str(msg))),
+        'trap-error': lambda thunk, handler: _trap_error(thunk, handler),
         'list?': lambda x: isinstance(x, list),
         'null?': lambda x: x == [],
         'length': lambda lst: len(lst),
         'symbol?': lambda x: isinstance(x, Symbol),
         'number?': lambda x: isinstance(x, (int, float)),
         'string?': lambda x: isinstance(x, str),
-        'apply': lambda f, args: f(*args),
         'map': lambda f, lst: [f(item) for item in lst],
         'filter': lambda pred, lst: [item for item in lst if pred(item)],
         'read-file': read_file,


### PR DESCRIPTION
## Summary
- add `kernel_env` providing minimal primitives
- extend `standard_env` from the kernel environment
- export `kernel_env` from bootstrap package
- document the new kernel environment in README and bootstrap docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f5ea630c832aa8a8b687fbd4ed47