### PR TITLE
Add read-line tests

### DIFF
--- a/toy/tests/test_read_line.py
+++ b/toy/tests/test_read_line.py
@@ -1,0 +1,40 @@
+import os, sys
+import subprocess
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from lispfun.interpreter import standard_env, parse
+from run_hosted import load_eval, eval_with_eval2
+from run_toy import load_toy
+
+
+def setup_env():
+    env = standard_env()
+    load_eval(env)
+    load_toy(env)
+    return env
+
+
+def test_read_line_returns_input(monkeypatch):
+    env = setup_env()
+    monkeypatch.setattr('builtins.input', lambda prompt='': 'hi')
+    result = eval_with_eval2(parse('(read-line "foo> ")'), env)
+    assert result == 'hi'
+
+
+def test_read_line_eof(monkeypatch):
+    env = setup_env()
+    def raise_eof(prompt=''):
+        raise EOFError
+    monkeypatch.setattr('builtins.input', raise_eof)
+    result = eval_with_eval2(parse('(read-line)'), env)
+    assert result == ''
+
+
+def test_run_toy_script_reads_line(tmp_path):
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    script = tmp_path / 'readline.lisp'
+    script.write_text('(print (read-line))')
+    cmd = [sys.executable, os.path.join(root, 'run_toy.py'), str(script)]
+    proc = subprocess.run(cmd, input='Hello\n', text=True, capture_output=True, check=True)
+    assert proc.stdout.strip() == 'Hello'
+

--- a/toy/tests/test_toy_repl_read_line.py
+++ b/toy/tests/test_toy_repl_read_line.py
@@ -1,0 +1,33 @@
+import builtins
+from lispfun.interpreter import standard_env
+from run_hosted import load_eval
+from run_toy import load_toy, python_toy_repl, lisp_toy_repl
+import pytest
+
+
+def setup_env():
+    env = standard_env()
+    load_eval(env)
+    load_toy(env)
+    return env
+
+
+def test_python_toy_repl_reads_line(monkeypatch, capsys):
+    """REPL implemented in Python should read a line and print it."""
+    env = setup_env()
+    inputs = iter(['(print (read-line))', 'hi', 'exit'])
+    monkeypatch.setattr(builtins, 'input', lambda prompt='': next(inputs))
+    python_toy_repl(env)
+    out, err = capsys.readouterr()
+    assert 'hi' in out
+
+
+@pytest.mark.xfail(reason="toy REPL written in Lisp fails to handle read-line")
+def test_lisp_toy_repl_reads_line(monkeypatch, capsys):
+    """Current Lisp REPL does not echo a line read via read-line."""
+    env = setup_env()
+    inputs = iter(['(print (read-line))', 'hi', 'exit'])
+    monkeypatch.setattr(builtins, 'input', lambda prompt='': next(inputs))
+    lisp_toy_repl(env)
+    out, err = capsys.readouterr()
+    assert 'hi' in out


### PR DESCRIPTION
## Summary
- add tests to verify `read-line` works in the toy interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780068b484832a8165f647d7d69ec6