### PR TITLE
Add kernel option to run_hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ you wish to bootstrap:
 
 ```bash
 ./run_bootstrap.py [file]   # pure Python interpreter
-./run_hosted.py [file]      # load evaluator.lisp and use eval2
+./run_hosted.py [--kernel] [file]      # load evaluator.lisp and use eval2
 ./run_toy.py [file]         # load evaluator and toy interpreter (toy REPL)
 ```
 Each script is executable so you can invoke it directly from the shell.
+Pass the optional ``--kernel`` flag to run ``eval2`` in the minimal
+``kernel_env`` instead of the full ``standard_env``.
 
 You can also pipe a short snippet into the toy interpreter by passing
 `/dev/stdin` as the file path:

--- a/run_hosted.py
+++ b/run_hosted.py
@@ -6,6 +6,7 @@ from lispfun.bootstrap.interpreter import (
     parse,
     parse_multiple,
     eval_lisp,
+    kernel_env,
     standard_env,
     to_string,
 )
@@ -58,11 +59,19 @@ def repl(env) -> None:
 
 
 def main() -> None:
-    env = standard_env()
+    """Run the hosted evaluator with optional ``--kernel`` flag."""
+    args = sys.argv[1:]
+    use_kernel = False
+    if args and args[0] == "--kernel":
+        use_kernel = True
+        args = args[1:]
+
+    env = kernel_env() if use_kernel else standard_env()
     load_eval(env)
-    if len(sys.argv) > 1:
-        env["args"] = sys.argv[2:]
-        run_file(sys.argv[1], env)
+
+    if args:
+        env["args"] = args[1:]
+        run_file(args[0], env)
     else:
         env["args"] = []
         repl(env)


### PR DESCRIPTION
## Summary
- allow run_hosted.py to run using the minimal kernel_env via `--kernel`
- document new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d979188c832a82440e9d3dad65dc