### PR TITLE
Fix toy repl and evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The repository now separates the main components for clarity:
   - Toy REPL prints evaluation results and accepts `'bye` as a shortcut to exit.
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
+  - `lambda` forms now allow multiple expressions in the body.
   - Loop macros `while` and `for` allow simple iterative code in the toy interpreter.
   - Toy interpreter now parses string literals.
   - Semicolon comments are recognized by the parser.

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -164,9 +164,12 @@ def eval_lisp(x: Any, env: Environment = global_env) -> Any:
         return val
     elif op_ == 'cond':
         for clause in args:
-            test, expr = clause
+            test, *body = clause
             if test == 'else' or eval_lisp(test, env):
-                return eval_lisp(expr, env)
+                val = None
+                for expr in body:
+                    val = eval_lisp(expr, env)
+                return val
         return None
     elif op_ == 'let':
         bindings, *body = args

--- a/lispfun/hosted/eval_core.lisp
+++ b/lispfun/hosted/eval_core.lisp
@@ -12,9 +12,9 @@
         None
         ((lambda (clause)
            (if (= (car clause) (quote else))
-               (eval2 (car (cdr clause)) env)
+               (eval-begin (cdr clause) env)
                (if (eval2 (car clause) env)
-                   (eval2 (car (cdr clause)) env)
+                   (eval-begin (cdr clause) env)
                    (eval-cond (cdr clauses) env))))
          (car clauses)))) )
 
@@ -43,7 +43,12 @@
                 (if (= op (quote set!))
                     (env-set! env (car args) (eval2 (car (cdr args)) env))
                     (if (= op (quote lambda))
-                        (make-procedure (car args) (car (cdr args)) env)
+                        (make-procedure
+                          (car args)
+                          (if (= (cdr (cdr args)) (quote ()))
+                              (car (cdr args))
+                              (cons (quote begin) (cdr args)))
+                          env)
                         (if (= op (quote begin))
                             (eval-begin args env)
                             (if (= op (quote cond))

--- a/run_toy.py
+++ b/run_toy.py
@@ -16,6 +16,8 @@ TOY_FILE = os.path.join(os.path.dirname(__file__), "toy", "toy-interpreter.lisp"
 
 def load_toy(env):
     """Load the toy interpreter implemented in Lisp."""
+    # Expose the host parser for use by the Lisp REPL
+    env['py-parse'] = parse
     with open(TOY_FILE) as f:
         code = f.read()
     for exp in parse_multiple(code):

--- a/toy/tests/test_toy_repl_read_line.py
+++ b/toy/tests/test_toy_repl_read_line.py
@@ -22,9 +22,8 @@ def test_python_toy_repl_reads_line(monkeypatch, capsys):
     assert 'hi' in out
 
 
-@pytest.mark.xfail(reason="toy REPL written in Lisp fails to handle read-line")
 def test_lisp_toy_repl_reads_line(monkeypatch, capsys):
-    """Current Lisp REPL does not echo a line read via read-line."""
+    """Lisp REPL implemented in toy interpreter should echo a line read via read-line."""
     env = setup_env()
     inputs = iter(['(print (read-line))', 'hi', 'exit'])
     monkeypatch.setattr(builtins, 'input', lambda prompt='': next(inputs))

--- a/toy/toy-repl.lisp
+++ b/toy/toy-repl.lisp
@@ -6,11 +6,14 @@
     (define line (read-line "toy> "))
     (cond
       ((or (= line "exit") (= line "") (= line "'bye"))
-       (print "bye")
-       'bye)
+       (begin
+         (print "bye")
+         (quote bye)))
       (else
-       (let ((result (eval-string line)))
-         (if result (print result)))
-       (toy-repl)))))
+       (begin
+         (let ((expr (py-parse line)))
+           (let ((result (eval2 expr env)))
+             (if result (print result) 0)))
+         (toy-repl))))))
 
 (toy-repl)


### PR DESCRIPTION
## Summary
- support multi-expression `cond` in bootstrap interpreter
- handle multi-expression lambda and cond in `eval_core.lisp`
- expose host parser to Lisp toy REPL
- implement toy REPL using host parser and eval2
- update README and remove xfail on toy REPL test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878d6cf8c6c832aadf7a5ad900c6862