### PR TITLE
Add kernel flag support to run_bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The repository now separates the main components for clarity:
 
 ## Completed Features
 
-- **Python bootstrap interpreter** with a REPL, basic arithmetic, variables and functions. A new `kernel_env` exposes only the minimal primitives used for bootstrapping. The full environment still provides list utilities `null?`, `length`, `map` and `filter`.
+ - **Python bootstrap interpreter** with a REPL, basic arithmetic, variables and functions. A new `kernel_env` exposes only the minimal primitives used for bootstrapping, and `run_bootstrap.py` accepts a `--kernel` flag to use it. The full environment still provides list utilities `null?`, `length`, `map` and `filter`.
 - **Self-hosted evaluator** written in Lisp loaded by `run_hosted.py` via `(import ...)`.
 - Lisp features implemented in Lisp:
   - `cond` form and `define-macro` for simple macros.
@@ -46,13 +46,13 @@ There are several helper scripts for running LispFun depending on how much Lisp 
 you wish to bootstrap:
 
 ```bash
-./run_bootstrap.py [file]   # pure Python interpreter
+./run_bootstrap.py [--kernel] [file]   # pure Python interpreter
 ./run_hosted.py [--kernel] [file]      # load evaluator.lisp and use eval2
 ./run_toy.py [file]         # load evaluator and toy interpreter (toy REPL)
 ```
 Each script is executable so you can invoke it directly from the shell.
-Pass the optional ``--kernel`` flag to run ``eval2`` in the minimal
-``kernel_env`` instead of the full ``standard_env``.
+Pass the optional ``--kernel`` flag to start either interpreter in the
+minimal ``kernel_env`` instead of the full ``standard_env``.
 
 You can also pipe a short snippet into the toy interpreter by passing
 `/dev/stdin` as the file path:

--- a/docs/bootstrap_interpreter.md
+++ b/docs/bootstrap_interpreter.md
@@ -5,8 +5,9 @@ The bootstrap interpreter in `interpreter.py` is the initial Python implementati
 Run the interpreter directly with:
 
 ```bash
-./run_bootstrap.py [path/to/file.lisp] [args...]
+./run_bootstrap.py [--kernel] [path/to/file.lisp] [args...]
 ```
 
-Omit the path to start the REPL. Any additional arguments after the file name
-are available inside the Lisp program via the `args` variable.
+Omit the path to start the REPL. Passing `--kernel` starts the interpreter with
+the minimal `kernel_env`. Any additional arguments after the file name are
+available inside the Lisp program via the `args` variable.

--- a/lispfun/bootstrap/tests/test_run_bootstrap_kernel_cli.py
+++ b/lispfun/bootstrap/tests/test_run_bootstrap_kernel_cli.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[3]
+run_bootstrap = root / 'run_bootstrap.py'
+basic_file = root / 'lispfun' / 'bootstrap' / 'tests' / 'lisp' / 'bootstrap.lisp'
+
+
+def test_run_bootstrap_kernel_cli():
+    proc = subprocess.run(
+        [sys.executable, str(run_bootstrap), '--kernel', str(basic_file)],
+        capture_output=True,
+    )
+    assert proc.returncode == 0
+

--- a/run_bootstrap.py
+++ b/run_bootstrap.py
@@ -5,6 +5,7 @@ from lispfun.bootstrap.interpreter import (
     parse,
     parse_multiple,
     eval_lisp,
+    kernel_env,
     standard_env,
     to_string,
 )
@@ -36,10 +37,17 @@ def repl(env) -> None:
 
 
 def main() -> None:
-    env = standard_env()
-    if len(sys.argv) > 1:
-        env["args"] = sys.argv[2:]
-        run_file(sys.argv[1], env)
+    """Run the bootstrap interpreter with optional ``--kernel`` flag."""
+    args = sys.argv[1:]
+    use_kernel = False
+    if args and args[0] == "--kernel":
+        use_kernel = True
+        args = args[1:]
+
+    env = kernel_env() if use_kernel else standard_env()
+    if args:
+        env["args"] = args[1:]
+        run_file(args[0], env)
     else:
         env["args"] = []
         repl(env)


### PR DESCRIPTION
## Summary
- allow run_bootstrap.py to run in `kernel_env` via `--kernel`
- document the new flag in README and bootstrap interpreter docs
- test CLI invocation of run_bootstrap with the kernel environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878eb31c000832abe68ef427570ea77