### PR TITLE
Clarify self hosting docs and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ The repository now separates the main components for clarity:
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.
 - A comprehensive unit test suite with Lisp programs stored alongside each interpreter.
 
+## Bootstrapping vs Self-Hosting
+
+`run_bootstrap.py` always launches the initial Python implementation.  It reads
+`evaluator.lisp` and loads `eval2` into the environment.  Once `eval2` is
+available the interpreter can evaluate its own source code purely in Lisp.  This
+ability to execute itself is what we call *self&#8209;hosting*.  Python remains
+responsible for parsing and starting the system, but after bootstrapping all
+evaluation is handled by Lisp code.
+
 ## Documentation
 
 Separate documents describe each interpreter:

--- a/docs/self_hosted_evaluator.md
+++ b/docs/self_hosted_evaluator.md
@@ -1,5 +1,12 @@
 # Self-hosted Evaluator
 
-`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator. The Python runner loads this file through `load_eval` in `run_hosted.py`. Once loaded, expressions are executed by wrapping them in `(eval2 ...)`.
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  The
+Python runner invokes `load_eval` in `run_hosted.py` to read this file and bring
+`eval2` into the environment.  Python is only needed for this initial
+bootstrapping step.  Afterward the interpreter can reload `evaluator.lisp` using
+`eval2` itself, so evaluation is handled entirely in Lisp.
 
-Helper modules such as `list_utils.lisp`, `string_utils.lisp` and `eval_core.lisp` provide primitives required by `eval2`. The evaluator understands macros defined with `define-macro` and is the foundation used by higher level code.
+Helper modules such as `list_utils.lisp`, `string_utils.lisp` and
+`eval_core.lisp` provide primitives required by `eval2`.  The evaluator
+understands macros defined with `define-macro` and is the foundation used by
+higher level code.

--- a/lispfun/hosted/README.md
+++ b/lispfun/hosted/README.md
@@ -1,5 +1,6 @@
 # Self-hosted Evaluator
 
 This directory contains the Lisp source files for the `eval2` evaluator.  The
-Python runner ``run_hosted.py`` loads ``evaluator.lisp`` from here and executes
-expressions via ``(eval2 ...)``.
+Python runner ``run_hosted.py`` reads ``evaluator.lisp`` and brings `eval2` into
+the environment.  Python performs this bootstrap step, after which `eval2` can
+evaluate the same file again or run other Lisp programs on its own.

--- a/lispfun/hosted/tests/test_self_hosting.py
+++ b/lispfun/hosted/tests/test_self_hosting.py
@@ -1,0 +1,35 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from lispfun.interpreter import (
+    parse,
+    parse_multiple,
+    eval_lisp,
+    standard_env,
+    to_string,
+)
+
+from run_hosted import load_eval, eval_with_eval2
+
+EVAL_FILE = os.path.join(os.path.dirname(__file__), "..", "evaluator.lisp")
+
+
+def load_eval_using_eval2(target_env, runner_env):
+    """Load evaluator.lisp into *target_env* using eval2 from *runner_env*."""
+    with open(EVAL_FILE) as f:
+        code = f.read()
+    for exp in parse_multiple(code):
+        program = f"(eval2 (quote {to_string(exp)}) target)"
+        eval_lisp(parse(program), runner_env)
+    target_env["env"] = target_env
+
+
+def test_eval2_can_bootstrap_another_env():
+    runner_env = standard_env()
+    load_eval(runner_env)  # bootstrap eval2 using Python
+    target_env = standard_env()
+    runner_env["target"] = target_env
+    load_eval_using_eval2(target_env, runner_env)
+    assert eval_with_eval2(parse("(+ 1 2)"), target_env) == 3
+


### PR DESCRIPTION
## Summary
- document the difference between bootstrapping and self‑hosting
- explain the self‑hosted evaluator bootstrap in docs
- clarify hosted README
- add a new test that loads `eval2` into a second environment using itself

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f2385a2c832a93f1a5e32ebf689d