### PR TITLE
Enable evaluator bootstrap in kernel env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ The repository now separates the main components for clarity:
    `--kernel` flag to start in these restricted environments.  The full
    environment still provides list utilities `null?`, `length`, `map` and
    `filter`.
-- **Self-hosted evaluator** written in Lisp loaded by `run_hosted.py` via `(import ...)`.
+ - **Self-hosted evaluator** written in Lisp loaded by `run_hosted.py` via `(import ...)`.
+ - `load_eval` now processes imports itself when `import` is undefined so the
+   evaluator boots even in the minimal `kernel_env`.
+ - The minimal `kernel_env` exposes `list?`, `symbol?`, `env-get`, `env-set!`
+   and `make-procedure` primitives required by `eval2` so the hosted evaluator
+   can run without enabling `import` or other convenience functions.
 - Lisp features implemented in Lisp:
   - `cond` form and `define-macro` for simple macros.
   - List utilities: `null?`, `length`, `map` and `filter`.

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -53,6 +53,11 @@ def kernel_env() -> Environment:
         'cdr': lambda x: x[1:],
         'cons': lambda x, y: [x] + y,
         'apply': lambda f, args: f(*args),
+        'list?': lambda x: isinstance(x, list),
+        'symbol?': lambda x: isinstance(x, Symbol),
+        'env-get': lambda env, var: env.find(var)[var],
+        'env-set!': lambda env, var, val: env.__setitem__(var, val),
+        'make-procedure': Procedure,
     })
     return env
 

--- a/lispfun/bootstrap/tests/test_kernel_bootstrap.py
+++ b/lispfun/bootstrap/tests/test_kernel_bootstrap.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
@@ -12,7 +11,8 @@ def test_kernel_basic_ops():
     assert eval_lisp(parse("(+ 1 2)"), env) == 3
 
 
-@pytest.mark.xfail(reason="kernel env missing 'import' for self-hosted evaluator")
-def test_load_eval_fails_in_kernel_env():
+def test_load_eval_in_kernel_env():
     env = kernel_env()
     load_eval(env)
+    assert "eval2" in env
+    assert "import" not in env

--- a/lispfun/hosted/tests/test_kernel_hosted.py
+++ b/lispfun/hosted/tests/test_kernel_hosted.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
@@ -7,7 +6,6 @@ from lispfun.interpreter import parse, kernel_env
 from run_hosted import load_eval, eval_with_eval2
 
 
-@pytest.mark.xfail(reason="self-hosted evaluator can't bootstrap with kernel env yet")
 def test_run_basic_with_kernel_env():
     env = kernel_env()
     load_eval(env)


### PR DESCRIPTION
## Summary
- teach `load_eval` to handle imports itself when `import` isn't available
- expose `list?`, `symbol?`, `env-get`, `env-set!` and `make-procedure` in the minimal `kernel_env`
- update bootstrap and hosted kernel tests to expect success
- document new capability in README
- assert `import` stays undefined after bootstrapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f3d8fd50832a95b6f153e1f6a2c4