### PR TITLE
Enable Lisp import on kernel bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The repository now separates the main components for clarity:
 
 ## Completed Features
 
- - **Python bootstrap interpreter** with a REPL, basic arithmetic, variables and functions. A new `kernel_env` exposes only the minimal primitives used for bootstrapping, and `run_bootstrap.py` accepts a `--kernel` flag to use it. The full environment still provides list utilities `null?`, `length`, `map` and `filter`.
-- **Self-hosted evaluator** written in Lisp loaded by `run_hosted.py` via `(import ...)`.
+ - **Python bootstrap interpreter** with a REPL, basic arithmetic, variables and functions. A new `kernel_env` exposes only the minimal primitives used for bootstrapping, including `read-file` but **not** `import`. `run_bootstrap.py` accepts a `--kernel` flag to use it. The full environment still provides list utilities `null?`, `length`, `map` and `filter`.
+ - **Self-hosted evaluator** written in Lisp. `run_hosted.py` loads the evaluator and its helper modules automatically, even when starting from the minimal `kernel_env`.
 - Lisp features implemented in Lisp:
   - `cond` form and `define-macro` for simple macros.
   - List utilities: `null?`, `length`, `map` and `filter`.

--- a/docs/bootstrap_interpreter.md
+++ b/docs/bootstrap_interpreter.md
@@ -1,6 +1,6 @@
 # Python Bootstrap Interpreter
 
-The bootstrap interpreter in `interpreter.py` is the initial Python implementation of LispFun. It provides a REPL and basic evaluation of arithmetic, variables and functions. A new `kernel_env` function returns only the primitives required for bootstrapping. The standard environment builds on top of this, exposing list and string helpers, `import` for loading Lisp files and other conveniences. It still includes simple list utilities like `null?`, `length`, `map` and `filter` so example programs run without additional modules.
+The bootstrap interpreter in `interpreter.py` is the initial Python implementation of LispFun. It provides a REPL and basic evaluation of arithmetic, variables and functions. A new `kernel_env` function returns only the primitives required for bootstrapping. It includes `read-file` so additional Lisp code can be loaded, but no `import` helper. The standard environment builds on top of this, exposing list and string helpers and a Python `import` for loading Lisp files. It still includes simple list utilities like `null?`, `length`, `map` and `filter` so example programs run without additional modules.
 
 Run the interpreter directly with:
 

--- a/docs/self_hosted_evaluator.md
+++ b/docs/self_hosted_evaluator.md
@@ -3,3 +3,8 @@
 `evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator. The Python runner loads this file through `load_eval` in `run_hosted.py`. Once loaded, expressions are executed by wrapping them in `(eval2 ...)`.
 
 Helper modules such as `list_utils.lisp`, `string_utils.lisp` and `eval_core.lisp` provide primitives required by `eval2`. The evaluator understands macros defined with `define-macro` and is the foundation used by higher level code.
+
+When bootstrapping from the minimal `kernel_env`, the loader handles the first
+few ``(import ...)`` forms itself so that the Lisp implementation of ``import``
+can be loaded. After ``import.lisp`` defines the helper in Lisp, further imports
+use that function.

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -53,6 +53,14 @@ def kernel_env() -> Environment:
         'cdr': lambda x: x[1:],
         'cons': lambda x, y: [x] + y,
         'apply': lambda f, args: f(*args),
+        'list?': lambda x: isinstance(x, list),
+        'symbol?': lambda x: isinstance(x, Symbol),
+        'env-get': lambda env, var: env.find(var)[var],
+        'env-set!': lambda env, var, val: env.__setitem__(var, val),
+        'make-procedure': Procedure,
+        'number?': lambda x: isinstance(x, (int, float)),
+        'string?': lambda x: isinstance(x, str),
+        'read-file': read_file,
     })
     return env
 
@@ -70,8 +78,6 @@ def standard_env() -> Environment:
         'null?': lambda x: x == [],
         'length': lambda lst: len(lst),
         'symbol?': lambda x: isinstance(x, Symbol),
-        'number?': lambda x: isinstance(x, (int, float)),
-        'string?': lambda x: isinstance(x, str),
         'map': lambda f, lst: [f(item) for item in lst],
         'filter': lambda pred, lst: [item for item in lst if pred(item)],
         'read-file': read_file,
@@ -86,12 +92,8 @@ def standard_env() -> Environment:
         # primitives used by Lisp parsing code
         'make-symbol': lambda name: Symbol(str(name)),
         'digits->number': lambda s: int(s) if '.' not in s else float(s),
-    })
-    # helpers for the self-hosted evaluator
-    env.update({
-        'env-get': lambda env, var: env.find(var)[var],
-        'env-set!': lambda env, var, val: env.__setitem__(var, val),
-        'make-procedure': Procedure,
+        'py-parse': parse,
+        'py-parse-multiple': parse_multiple,
     })
     # ability to load additional Lisp files
     def import_file(fname: str):
@@ -105,6 +107,8 @@ def standard_env() -> Environment:
                 result = eval_lisp(parse(program), env)
             else:
                 result = eval_lisp(exp, env)
+        if "eval2" not in env:
+            env["import"] = import_file
         return result
 
     env.update({

--- a/lispfun/bootstrap/tests/test_kernel_bootstrap.py
+++ b/lispfun/bootstrap/tests/test_kernel_bootstrap.py
@@ -12,7 +12,7 @@ def test_kernel_basic_ops():
     assert eval_lisp(parse("(+ 1 2)"), env) == 3
 
 
-@pytest.mark.xfail(reason="kernel env missing 'import' for self-hosted evaluator")
-def test_load_eval_fails_in_kernel_env():
+def test_load_eval_in_kernel_env():
     env = kernel_env()
     load_eval(env)
+    assert 'eval2' in env

--- a/lispfun/hosted/evaluator.lisp
+++ b/lispfun/hosted/evaluator.lisp
@@ -1,3 +1,4 @@
+(import "lispfun/hosted/import.lisp")
 (import "lispfun/hosted/list_utils.lisp")
 (import "lispfun/hosted/string_utils.lisp")
 (import "lispfun/hosted/eval_core.lisp")

--- a/lispfun/hosted/import.lisp
+++ b/lispfun/hosted/import.lisp
@@ -1,0 +1,11 @@
+(define import
+  (lambda (path)
+    (let ((code (read-file path)))
+      (define exprs (py-parse-multiple code))
+      (define loop
+        (lambda (es result)
+          (if (null? es)
+              result
+              (loop (cdr es) (eval2 (car es) env)))))
+      (loop exprs 0)))
+)

--- a/lispfun/hosted/tests/test_kernel_hosted.py
+++ b/lispfun/hosted/tests/test_kernel_hosted.py
@@ -7,7 +7,6 @@ from lispfun.interpreter import parse, kernel_env
 from run_hosted import load_eval, eval_with_eval2
 
 
-@pytest.mark.xfail(reason="self-hosted evaluator can't bootstrap with kernel env yet")
 def test_run_basic_with_kernel_env():
     env = kernel_env()
     load_eval(env)


### PR DESCRIPTION
## Summary
- expose `read-file` in `kernel_env` and add host parsing helpers to the standard env
- implement `import` in Lisp under `lispfun/hosted/import.lisp`
- `load_eval` now loads required files explicitly and installs the Lisp import
- toy loader exposes `py-parse-multiple` for the new import code
- docs updated to describe bootstrapping without an import primitive

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ef404e34832a94548847de1d6fea