### PR TITLE
Switch toy REPL to toy parser

### DIFF
--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -30,6 +30,7 @@ The repository now separates the main components for clarity:
   - Predicates `number?` and `string?` for identifying literal types.
   - `read-line` primitive for interactive input.
   - Toy REPL prints evaluation results and accepts `'bye` as a shortcut to exit.
+  - The REPL uses the toy parser, so it no longer relies on the host parser.
   - `(import "file")` for loading additional Lisp code.
   - Toy interpreter supports `define-macro` so macros work when running example scripts.
   - `lambda` forms now allow multiple expressions in the body.

--- a/run_toy.py
+++ b/run_toy.py
@@ -16,8 +16,6 @@ TOY_FILE = os.path.join(os.path.dirname(__file__), "toy", "toy-interpreter.lisp"
 
 def load_toy(env):
     """Load the toy interpreter implemented in Lisp."""
-    # Expose the host parser for use by the Lisp REPL
-    env["py-parse"] = parse
 
     # Ensure all standard environment symbols are available when starting from
     # the minimal ``kernel_env``.

--- a/toy/toy-repl.lisp
+++ b/toy/toy-repl.lisp
@@ -11,7 +11,7 @@
          (quote bye)))
       (else
        (begin
-         (let ((expr (py-parse line)))
+         (let ((expr (parse line)))
            (let ((result (eval2 expr env)))
              (if result (print result) 0)))
          (toy-repl))))))


### PR DESCRIPTION
## Summary
- remove Python parser from toy environment
- update toy REPL to call `parse`
- document that the toy REPL relies on its own parser

## Testing
- `pytest -q` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68790646fdb0832a8f28e5a305cc317b