### PR TITLE
Expand toy Lisp environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Helper scripts in the repository root run the different interpreters:
 Pass `--kernel` to start in the restricted bootstrap environment.  See the
 individual documents under `docs/` and `lispfun/README.md` for full usage and
 development notes.
+
+The toy interpreter continues to grow. It now defines common primitives such as
+`<=`, `>=`, `abs`, `max`, `min` and a Lisp version of `apply` itself, though it
+still relies on Python for low level string operations and environment helpers.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -15,6 +15,10 @@ loops can be written without modifying the evaluator.
 
 Basic predicates `number?` and `string?` are available and the tokenizer handles
 quoted strings.
+Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
+implementation of `apply` further reduce the reliance on Python.
+The interpreter still depends on the host for low level string primitives and
+environment manipulation.
 The `(require "file.lisp")` form loads a Lisp file only once so modules aren't
 imported multiple times.
 `(error "msg")` raises an exception and `(trap-error thunk handler)` can be

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -38,6 +38,10 @@ The repository now separates the main components for clarity:
   - Semicolon comments are recognized by the parser.
   - Command line arguments after the script name are available as the `args` list.
   - `(require "file")` loads Lisp files once to support a basic module system.
+  - Additional primitives `<=`, `>=`, `abs`, `max`, `min` and a Lisp
+    implementation of `apply` are now defined in `toy-evaluator.lisp`. The toy
+    interpreter still depends on the host environment for string utilities and
+    low level environment helpers.
   - `(error "msg")` raises an exception and `(trap-error thunk handler)`
     invokes `handler` with the message if evaluating `thunk` fails.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.

--- a/toy/toy-evaluator.lisp
+++ b/toy/toy-evaluator.lisp
@@ -72,6 +72,12 @@
     (list "=" =)
     (list "<" <)
     (list ">" >)
+    (list "<=" (lambda (a b) (or (< a b) (= a b))))
+    (list ">=" (lambda (a b) (or (> a b) (= a b))))
+    (list "abs" (lambda (x) (if (< x 0) (- 0 x) x)))
+    (list "max" (lambda (a b) (if (> a b) a b)))
+    (list "min" (lambda (a b) (if (< a b) a b)))
+    (list "apply" (lambda (f args) (apply-closure f args)))
     (list "list" list)
     (list "car" car)
     (list "cdr" cdr)
@@ -98,6 +104,9 @@
 (define not
   (lambda (x)
     (if x 0 1)))
+
+; Extra primitives implemented in Lisp now that the environment exists
+
 
 ; List access helpers used by the evaluator and parser
 (define cadr (lambda (lst) (car (cdr lst))))


### PR DESCRIPTION
## Summary
- implement core primitives in `toy/toy-evaluator.lisp`
- note new features in all documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687906f9b214832ab82aa2e0dbc5e216