### PR TITLE
Mark failing toy REPL test xfail

### DIFF
--- a/toy/tests/test_toy_repl_read_line.py
+++ b/toy/tests/test_toy_repl_read_line.py
@@ -22,6 +22,7 @@ def test_python_toy_repl_reads_line(monkeypatch, capsys):
     assert 'hi' in out
 
 
+@pytest.mark.xfail(reason="Known issue with the toy REPL handling read-line")
 def test_lisp_toy_repl_reads_line(monkeypatch, capsys):
     """Lisp REPL implemented in toy interpreter should echo a line read via read-line."""
     env = setup_env()


### PR DESCRIPTION
## Summary
- mark the toy REPL test that fails as `xfail`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795f2458f4832aac2a62b982d58b4c