### PR TITLE
Rewrite bootstrap eval to use iterative stack

### DIFF
--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -20,9 +20,11 @@ The repository now separates the main components for clarity:
  - **Self-hosted evaluator** written in Lisp loaded by `run_hosted.py` via `(import ...)`.
  - `load_eval` now processes imports itself when `import` is undefined so the
    evaluator boots even in the minimal `kernel_env`.
- - The minimal `kernel_env` exposes `list?`, `symbol?`, `env-get`, `env-set!`
-   and `make-procedure` primitives required by `eval2` so the hosted evaluator
-   can run without enabling `import` or other convenience functions.
+  - The minimal `kernel_env` exposes `list?`, `symbol?`, `env-get`, `env-set!`
+    and `make-procedure` primitives required by `eval2` so the hosted evaluator
+    can run without enabling `import` or other convenience functions.
+  - The bootstrap evaluator now runs iteratively using its own stack so deep
+    recursion no longer hits Python's recursion limit.
 - Lisp features implemented in Lisp:
   - `cond` form and `define-macro` for simple macros.
   - List utilities: `null?`, `length`, `map` and `filter`.


### PR DESCRIPTION
## Summary
- rework the bootstrap `eval_lisp` to avoid Python recursion by using an explicit stack
- update the `apply` primitive to call the new evaluator when given a Lisp `Procedure`
- document the iterative bootstrap evaluator in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687961e655ec832ab6f560e4f6de6546