### PR TITLE
Add Lisp implementations for list helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Pass `--kernel` to start in the restricted bootstrap environment.  See the
 individual documents under `docs/` and `lispfun/README.md` for full usage and
 development notes.
 
-The toy interpreter continues to grow. It now defines common primitives such as
-`<=`, `>=`, `abs`, `max`, `min` and a Lisp version of `apply` itself, though it
-still relies on Python for low level string operations and environment helpers.
+The toy interpreter continues to grow.  In addition to `<=`, `>=`, `abs`, `max`,
+`min` and a Lisp version of `apply`, several primitives from the Python
+environment are now reimplemented purely in Lisp:
+
+- `null?` – check for the empty list
+- `length` – compute list length
+- `map` – apply a function to each element
+- `filter` – select elements matching a predicate
+
+String operations and type predicates (`number?`, `string?`, `symbol?`,
+`list?`), along with file I/O, still rely on the Python runtime.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -16,9 +16,11 @@ loops can be written without modifying the evaluator.
 Basic predicates `number?` and `string?` are available and the tokenizer handles
 quoted strings.
 Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
-implementation of `apply` further reduce the reliance on Python.
+implementation of `apply` further reduce the reliance on Python.  The
+operations `null?`, `length`, `map` and `filter` are also implemented in Lisp.
 The interpreter still depends on the host for low level string primitives and
-environment manipulation.
+type checks (`number?`, `string?`, `symbol?`, `list?`) as well as environment
+manipulation.
 The `(require "file.lisp")` form loads a Lisp file only once so modules aren't
 imported multiple times.
 `(error "msg")` raises an exception and `(trap-error thunk handler)` can be

--- a/toy/toy-evaluator.lisp
+++ b/toy/toy-evaluator.lisp
@@ -57,9 +57,11 @@
 
 (define apply-closure
   (lambda (proc args)
-    (if (and (list? proc) (= (car proc) 'closure))
-        (eval-expr (caddr proc)
-                   (extend-env (cadddr proc) (cadr proc) args))
+    (if (list? proc)
+        (if (= (car proc) 'closure)
+            (eval-expr (caddr proc)
+                       (extend-env (cadddr proc) (cadr proc) args))
+            (apply proc args))
         (apply proc args))))
 
 ; Simple global environment with arithmetic primitives
@@ -101,11 +103,41 @@
   (lambda (a b)
     (if a b a)))
 
+
 (define not
   (lambda (x)
     (if x 0 1)))
 
 ; Extra primitives implemented in Lisp now that the environment exists
+
+; Check for the empty list without relying on Python
+(define null?
+  (lambda (x)
+    (= x (quote ()))))
+
+; Compute the length of a list recursively
+(define length
+  (lambda (lst)
+    (if (null? lst)
+        0
+        (+ 1 (length (cdr lst))))) )
+
+; Map a function over a list using apply-closure so closures work
+(define map
+  (lambda (f lst)
+    (if (null? lst)
+        (quote ())
+        (cons (apply-closure f (list (car lst)))
+              (map f (cdr lst))))))
+
+; Filter a list according to predicate f
+(define filter
+  (lambda (pred lst)
+    (if (null? lst)
+        (quote ())
+        (if (apply-closure pred (list (car lst)))
+            (cons (car lst) (filter pred (cdr lst)))
+            (filter pred (cdr lst))))))
 
 
 ; List access helpers used by the evaluator and parser


### PR DESCRIPTION
## Summary
- implement `null?`, `length`, `map` and `filter` directly in `toy-evaluator.lisp`
- improve `apply-closure` so non-list procedures don't raise errors
- document new Lisp primitives in the main README and toy docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796aa44c20832a915244f9a977015d