### PR TITLE
Add interpreter capabilities documentation

### DIFF
--- a/docs/interpreter_capabilities.md
+++ b/docs/interpreter_capabilities.md
@@ -1,0 +1,26 @@
+# Interpreter Capabilities
+
+This document summarizes what is available in the different LispFun interpreters.  The Python bootstrap interpreter exposes a very small core so that the rest of the system can be implemented in Lisp.  The self‑hosted evaluator, written in Lisp, reuses the same primitives but performs evaluation in Lisp code.
+
+## Bootstrap Interpreter
+
+The bootstrap interpreter lives in `lispfun/bootstrap`.  Its tokenizer handles parentheses, numbers, symbols and quoted strings.  Semicolons introduce comments that run until the end of the line.  The parser provides `parse` for a single expression and `parse_multiple` for a whole file.  `to_string` converts expressions back to a textual representation.
+
+Evaluation is limited to a small set of special forms and primitives:
+
+- Special forms: `quote`, `if`, `define`, `set!`, `lambda`, `begin`, `cond` and `let`.
+- Arithmetic: `+`, `-`, `*`, `/`.
+- Comparisons: `>`, `<`, `>=`, `<=`, `=`.
+- List primitives: `list`, `car`, `cdr`, `cons`, and a host‑side `apply`.
+- Environment helpers: `env-get`, `env-set!`, `make-procedure`.
+- Predicates and utilities in the standard environment such as `null?`, `length`, `map`, `filter`, `number?`, `string?`, `read-file`, `read-line` and simple string helpers (`string-length`, `string-slice`, `string-concat`, `make-string`, `char-code`, `chr`).
+- `(import "file.lisp")` loads additional Lisp source using the same parser and evaluator.
+- Error handling via `(error "msg")` and `(trap-error thunk handler)`.
+
+This kernel is intentionally small but complete enough to load Lisp source code that implements a more capable evaluator.
+
+## Self-hosted Evaluator
+
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities that are themselves written in Lisp.
+
+When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  Higher‑level code, including the toy interpreter in `toy/`, can then be built entirely in Lisp on top of this evaluator.

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -66,6 +66,7 @@ Separate documents describe each interpreter:
 - [Python bootstrap interpreter](docs/bootstrap_interpreter.md)
 - [Self-hosted evaluator](docs/self_hosted_evaluator.md)
 - [Lisp toy interpreter](docs/toy_interpreter.md)
+- [Interpreter capabilities](docs/interpreter_capabilities.md)
 
 ## Running the Interpreter
 


### PR DESCRIPTION
## Summary
- document operators and parsing support in new Interpreter Capabilities doc
- link the new doc from `lispfun/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796af53168832a8bb3a7f961cc10d2