### PR TITLE
Implement Lisp string-length

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ environment are now reimplemented purely in Lisp:
 - `length` – compute list length
 - `map` – apply a function to each element
 - `filter` – select elements matching a predicate
+- `string-length` – compute the length of a string
 
-String operations and type predicates (`number?`, `string?`, `symbol?`,
+Other string operations and type predicates (`number?`, `string?`, `symbol?`,
 `list?`), along with file I/O, still rely on the Python runtime.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Pass `--kernel` to start in the restricted bootstrap environment.  See the
 individual documents under `docs/` and `lispfun/README.md` for full usage and
 development notes.
 
-The toy interpreter continues to grow.  In addition to `<=`, `>=`, `abs`, `max`,
-`min` and a Lisp version of `apply`, several primitives from the Python
-environment are now reimplemented purely in Lisp:
+The toy interpreter is now completely self-hosted.  It ships with a tokenizer
+and parser written in Lisp so programs run without using the Python parser once
+bootstrapped.  In addition to `<=`, `>=`, `abs`, `max`, `min` and a Lisp version
+of `apply`, several primitives from the Python environment are now
+reimplemented purely in Lisp:
 
 - `null?` – check for the empty list
 - `length` – compute list length
@@ -38,5 +40,10 @@ environment are now reimplemented purely in Lisp:
 - `filter` – select elements matching a predicate
 - `string-length` – compute the length of a string
 
-Other string operations and type predicates (`number?`, `string?`, `symbol?`,
-`list?`), along with file I/O, still rely on the Python runtime.
+The remaining host-provided primitives are:
+- low level string helpers `string-slice`, `string-concat`, `make-string`,
+  `char-code` and `chr`
+- type predicates `number?`, `string?`, `symbol?` and `list?`
+- symbol utilities `make-symbol` and `digits->number`
+- environment helpers `env-get`, `env-set!` and `make-procedure`
+- file I/O primitives `read-file` and `read-line`

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ reimplemented purely in Lisp:
 - `filter` – select elements matching a predicate
 - `string-length` – compute the length of a string
 - `digits->number` – convert a string of digits to a number
+- `number?` – check if a value is numeric
+- `string?` – check if a value is a string
 - Numeric helpers `<=`, `>=`, `abs`, `max` and `min`
 
 The remaining host-provided primitives are:
 - low level string helpers `string-slice`, `string-concat`, `make-string`,
   `char-code` and `chr`
-- type predicates `number?`, `string?`, `symbol?` and `list?`
+- type predicates `symbol?` and `list?`
 - symbol utility `make-symbol`
 - environment helpers `env-get`, `env-set!` and `make-procedure`
 - file I/O primitives `read-file` and `read-line`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ reimplemented purely in Lisp:
 - `filter` – select elements matching a predicate
 - `string-length` – compute the length of a string
 - `digits->number` – convert a string of digits to a number
+- Numeric helpers `<=`, `>=`, `abs`, `max` and `min`
 
 The remaining host-provided primitives are:
 - low level string helpers `string-slice`, `string-concat`, `make-string`,

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ reimplemented purely in Lisp:
 - `map` – apply a function to each element
 - `filter` – select elements matching a predicate
 - `string-length` – compute the length of a string
+- `digits->number` – convert a string of digits to a number
 
 The remaining host-provided primitives are:
 - low level string helpers `string-slice`, `string-concat`, `make-string`,
   `char-code` and `chr`
 - type predicates `number?`, `string?`, `symbol?` and `list?`
-- symbol utilities `make-symbol` and `digits->number`
+- symbol utility `make-symbol`
 - environment helpers `env-get`, `env-set!` and `make-procedure`
 - file I/O primitives `read-file` and `read-line`

--- a/docs/interpreter_capabilities.md
+++ b/docs/interpreter_capabilities.md
@@ -21,6 +21,6 @@ This kernel is intentionally small but complete enough to load Lisp source code 
 
 ## Self-hosted Evaluator
 
-`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities—now including a Lisp version of `string-length`—that are themselves written in Lisp.
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities—now including Lisp versions of `string-length` and `digits->number`—that are themselves written in Lisp.
 
 When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  The toy interpreter in `toy/` supplies its own tokenizer and parser so it can run entirely in Lisp once the evaluator is loaded.

--- a/docs/interpreter_capabilities.md
+++ b/docs/interpreter_capabilities.md
@@ -21,6 +21,6 @@ This kernel is intentionally small but complete enough to load Lisp source code 
 
 ## Self-hosted Evaluator
 
-`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list, string and numeric utilities—now including Lisp versions of `<=`, `>=`, `abs`, `max`, `min`, `string-length` and `digits->number`—that are themselves written in Lisp.
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list, string and numeric utilities—now including Lisp versions of `<=`, `>=`, `abs`, `max`, `min`, `string-length`, `digits->number`, `number?` and `string?`—that are themselves written in Lisp.
 
 When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  The toy interpreter in `toy/` supplies its own tokenizer and parser so it can run entirely in Lisp once the evaluator is loaded.

--- a/docs/interpreter_capabilities.md
+++ b/docs/interpreter_capabilities.md
@@ -21,6 +21,6 @@ This kernel is intentionally small but complete enough to load Lisp source code 
 
 ## Self-hosted Evaluator
 
-`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities that are themselves written in Lisp.
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities—now including a Lisp version of `string-length`—that are themselves written in Lisp.
 
 When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  Higher‑level code, including the toy interpreter in `toy/`, can then be built entirely in Lisp on top of this evaluator.

--- a/docs/interpreter_capabilities.md
+++ b/docs/interpreter_capabilities.md
@@ -21,6 +21,6 @@ This kernel is intentionally small but complete enough to load Lisp source code 
 
 ## Self-hosted Evaluator
 
-`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities—now including Lisp versions of `string-length` and `digits->number`—that are themselves written in Lisp.
+`evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list, string and numeric utilities—now including Lisp versions of `<=`, `>=`, `abs`, `max`, `min`, `string-length` and `digits->number`—that are themselves written in Lisp.
 
 When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  The toy interpreter in `toy/` supplies its own tokenizer and parser so it can run entirely in Lisp once the evaluator is loaded.

--- a/docs/interpreter_capabilities.md
+++ b/docs/interpreter_capabilities.md
@@ -23,4 +23,4 @@ This kernel is intentionally small but complete enough to load Lisp source code 
 
 `evaluator.lisp` defines `eval2`, a Lisp implementation of the evaluator.  It uses the same parser functions provided by the bootstrap interpreter.  Once `eval2` is loaded, evaluation occurs purely in Lisp.  The self-hosted interpreter supports all of the above forms and additionally understands `define-macro` so macros expand before execution.  Helper modules in `lispfun/hosted` implement list and string utilities—now including a Lisp version of `string-length`—that are themselves written in Lisp.
 
-When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  Higher‑level code, including the toy interpreter in `toy/`, can then be built entirely in Lisp on top of this evaluator.
+When run through `run_hosted.py`, the evaluator uses `eval2` for every expression but still relies on Python to tokenize and parse unless another parser is loaded.  The toy interpreter in `toy/` supplies its own tokenizer and parser so it can run entirely in Lisp once the evaluator is loaded.

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -16,8 +16,9 @@ loops can be written without modifying the evaluator.
 Basic predicates `number?` and `string?` are available and the tokenizer handles
 quoted strings.
 Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
-implementation of `apply` further reduce the reliance on Python.  The
-operations `null?`, `length`, `string-length`, `digits->number`, `map` and `filter` are also
+implementation of `apply` further reduce the reliance on Python.  These numeric
+utilities live in `numeric_utils.lisp`.  The operations `null?`, `length`,
+`string-length`, `digits->number`, `map` and `filter` are also
 implemented in Lisp.  The toy interpreter supplies its own tokenizer and parser
 so evaluation occurs entirely in Lisp once it is loaded.  Remaining host
 dependencies include low level string primitives (`string-slice`,

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -18,12 +18,12 @@ quoted strings.
 Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
 implementation of `apply` further reduce the reliance on Python.  These numeric
 utilities live in `numeric_utils.lisp`.  The operations `null?`, `length`,
-`string-length`, `digits->number`, `map` and `filter` are also
+`string-length`, `digits->number`, `number?`, `string?`, `map` and `filter` are also
 implemented in Lisp.  The toy interpreter supplies its own tokenizer and parser
 so evaluation occurs entirely in Lisp once it is loaded.  Remaining host
 dependencies include low level string primitives (`string-slice`,
-`string-concat`, `make-string`, `char-code`, `chr`) and type checks (`number?`,
-`string?`, `symbol?`, `list?`) along with environment manipulation.
+`string-concat`, `make-string`, `char-code`, `chr`) and type checks (`symbol?`,
+`list?`) along with environment manipulation.
 The `(require "file.lisp")` form loads a Lisp file only once so modules aren't
 imported multiple times.
 `(error "msg")` raises an exception and `(trap-error thunk handler)` can be

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -17,8 +17,9 @@ Basic predicates `number?` and `string?` are available and the tokenizer handles
 quoted strings.
 Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
 implementation of `apply` further reduce the reliance on Python.  The
-operations `null?`, `length`, `map` and `filter` are also implemented in Lisp.
-The interpreter still depends on the host for low level string primitives and
+operations `null?`, `length`, `string-length`, `map` and `filter` are also
+implemented in Lisp. The interpreter still depends on the host for other low
+level string primitives and
 type checks (`number?`, `string?`, `symbol?`, `list?`) as well as environment
 manipulation.
 The `(require "file.lisp")` form loads a Lisp file only once so modules aren't

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -18,10 +18,11 @@ quoted strings.
 Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
 implementation of `apply` further reduce the reliance on Python.  The
 operations `null?`, `length`, `string-length`, `map` and `filter` are also
-implemented in Lisp. The interpreter still depends on the host for other low
-level string primitives and
-type checks (`number?`, `string?`, `symbol?`, `list?`) as well as environment
-manipulation.
+implemented in Lisp.  The toy interpreter supplies its own tokenizer and parser
+so evaluation occurs entirely in Lisp once it is loaded.  Remaining host
+dependencies include low level string primitives (`string-slice`,
+`string-concat`, `make-string`, `char-code`, `chr`) and type checks (`number?`,
+`string?`, `symbol?`, `list?`) along with environment manipulation.
 The `(require "file.lisp")` form loads a Lisp file only once so modules aren't
 imported multiple times.
 `(error "msg")` raises an exception and `(trap-error thunk handler)` can be

--- a/docs/toy_interpreter.md
+++ b/docs/toy_interpreter.md
@@ -17,7 +17,7 @@ Basic predicates `number?` and `string?` are available and the tokenizer handles
 quoted strings.
 Additional helpers like `<=`, `>=`, `abs`, `max`, `min` and a Lisp
 implementation of `apply` further reduce the reliance on Python.  The
-operations `null?`, `length`, `string-length`, `map` and `filter` are also
+operations `null?`, `length`, `string-length`, `digits->number`, `map` and `filter` are also
 implemented in Lisp.  The toy interpreter supplies its own tokenizer and parser
 so evaluation occurs entirely in Lisp once it is loaded.  Remaining host
 dependencies include low level string primitives (`string-slice`,

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -29,7 +29,7 @@ The repository now separates the main components for clarity:
   - `cond` form and `define-macro` for simple macros.
   - List utilities: `null?`, `length`, `map` and `filter`.
   - String helpers: `parse-string`, `string-for-each`, `build-string`,
-    `string-length`.
+    `string-length`, `digits->number`.
   - Predicates `number?` and `string?` for identifying literal types.
   - `read-line` primitive for interactive input.
   - Toy REPL prints evaluation results and accepts `'bye` as a shortcut to exit.

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -28,7 +28,8 @@ The repository now separates the main components for clarity:
 - Lisp features implemented in Lisp:
   - `cond` form and `define-macro` for simple macros.
   - List utilities: `null?`, `length`, `map` and `filter`.
-  - String helpers: `parse-string`, `string-for-each`, `build-string`.
+  - String helpers: `parse-string`, `string-for-each`, `build-string`,
+    `string-length`.
   - Predicates `number?` and `string?` for identifying literal types.
   - `read-line` primitive for interactive input.
   - Toy REPL prints evaluation results and accepts `'bye` as a shortcut to exit.
@@ -43,8 +44,8 @@ The repository now separates the main components for clarity:
   - `(require "file")` loads Lisp files once to support a basic module system.
   - Additional primitives `<=`, `>=`, `abs`, `max`, `min` and a Lisp
     implementation of `apply` are now defined in `toy-evaluator.lisp`. The toy
-    interpreter still depends on the host environment for string utilities and
-    low level environment helpers.
+    interpreter still depends on the host environment for most string utilities
+    and low level environment helpers.
   - `(error "msg")` raises an exception and `(trap-error thunk handler)`
     invokes `handler` with the message if evaluating `thunk` fails.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -30,6 +30,8 @@ The repository now separates the main components for clarity:
   - List utilities: `null?`, `length`, `map` and `filter`.
   - String helpers: `parse-string`, `string-for-each`, `build-string`,
     `string-length`, `digits->number`.
+  - Numeric helpers `<=`, `>=`, `abs`, `max` and `min` implemented in
+    `numeric_utils.lisp`.
   - Predicates `number?` and `string?` for identifying literal types.
   - `read-line` primitive for interactive input.
   - Toy REPL prints evaluation results and accepts `'bye` as a shortcut to exit.
@@ -42,8 +44,7 @@ The repository now separates the main components for clarity:
   - Semicolon comments are recognized by the parser.
   - Command line arguments after the script name are available as the `args` list.
   - `(require "file")` loads Lisp files once to support a basic module system.
-  - Additional primitives `<=`, `>=`, `abs`, `max`, `min` and a Lisp
-    implementation of `apply` are now defined in `toy-evaluator.lisp`.
+  - A Lisp implementation of `apply` is provided in `toy-evaluator.lisp`.
     Low level primitives such as `string-slice`, `string-concat`, `make-string`,
     `char-code`, `chr` and the type predicates still come from Python along with
     environment helpers like `env-get` and `env-set!`.

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -46,7 +46,7 @@ The repository now separates the main components for clarity:
   - `(require "file")` loads Lisp files once to support a basic module system.
   - A Lisp implementation of `apply` is provided in `toy-evaluator.lisp`.
     Low level primitives such as `string-slice`, `string-concat`, `make-string`,
-    `char-code`, `chr` and the type predicates still come from Python along with
+    `char-code`, `chr` and the remaining type predicates still come from Python along with
     environment helpers like `env-get` and `env-set!`.
   - `(error "msg")` raises an exception and `(trap-error thunk handler)`
     invokes `handler` with the message if evaluating `thunk` fails.

--- a/lispfun/README.md
+++ b/lispfun/README.md
@@ -43,9 +43,10 @@ The repository now separates the main components for clarity:
   - Command line arguments after the script name are available as the `args` list.
   - `(require "file")` loads Lisp files once to support a basic module system.
   - Additional primitives `<=`, `>=`, `abs`, `max`, `min` and a Lisp
-    implementation of `apply` are now defined in `toy-evaluator.lisp`. The toy
-    interpreter still depends on the host environment for most string utilities
-    and low level environment helpers.
+    implementation of `apply` are now defined in `toy-evaluator.lisp`.
+    Low level primitives such as `string-slice`, `string-concat`, `make-string`,
+    `char-code`, `chr` and the type predicates still come from Python along with
+    environment helpers like `env-get` and `env-set!`.
   - `(error "msg")` raises an exception and `(trap-error thunk handler)`
     invokes `handler` with the message if evaluating `thunk` fails.
 - Example scripts demonstrate factorials, Fibonacci numbers, list processing, macros and loops.
@@ -197,5 +198,9 @@ Run `./run_example_tests.sh` from the repository root to try each interpreter on
 
 ## Work Remaining
 
-Python still handles tokenizing and parsing in `interpreter.py`. The long term goal is to move these pieces to Lisp. See `toy/IDEAS.md` for additional future enhancements like full self-hosting and improved debugging.
+The bootstrap and hosted interpreters rely on the Python tokenizer and parser.
+The toy interpreter already provides Lisp versions of these components so it can
+run entirely in Lisp once bootstrapped.  Future work includes expanding the
+standard library and adding debugging tools.  See `toy/IDEAS.md` for more
+potential enhancements.
 

--- a/lispfun/hosted/evaluator.lisp
+++ b/lispfun/hosted/evaluator.lisp
@@ -1,5 +1,6 @@
 (import "lispfun/hosted/list_utils.lisp")
 (import "lispfun/hosted/string_utils.lisp")
 (import "lispfun/hosted/numeric_utils.lisp")
+(import "lispfun/hosted/type_predicates.lisp")
 (import "lispfun/hosted/eval_core.lisp")
 

--- a/lispfun/hosted/evaluator.lisp
+++ b/lispfun/hosted/evaluator.lisp
@@ -1,4 +1,5 @@
 (import "lispfun/hosted/list_utils.lisp")
 (import "lispfun/hosted/string_utils.lisp")
+(import "lispfun/hosted/numeric_utils.lisp")
 (import "lispfun/hosted/eval_core.lisp")
 

--- a/lispfun/hosted/numeric_utils.lisp
+++ b/lispfun/hosted/numeric_utils.lisp
@@ -1,0 +1,23 @@
+(define <=
+  (lambda (a b)
+    (if (< a b)
+        1
+        (if (= a b) 1 0))))
+
+(define >=
+  (lambda (a b)
+    (if (> a b)
+        1
+        (if (= a b) 1 0))))
+
+(define abs
+  (lambda (x)
+    (if (< x 0) (- 0 x) x)))
+
+(define max
+  (lambda (a b)
+    (if (> a b) a b)))
+
+(define min
+  (lambda (a b)
+    (if (< a b) a b)))

--- a/lispfun/hosted/string_utils.lisp
+++ b/lispfun/hosted/string_utils.lisp
@@ -8,6 +8,53 @@
               (iter (+ i 1)))))
       (iter 0))))
 
+; Convert a string containing digits (and an optional decimal point)
+; into a number.  Handles a leading '-' for negative values.
+(define digits->number
+  (lambda (s)
+    (begin
+      (define len (string-length s))
+      (define start 0)
+      (define sign 1)
+      (if (> len 0)
+          (if (= (string-slice s 0 1) "-")
+              (begin
+                (set! start 1)
+                (set! sign -1))
+              0)
+          0)
+      (define find-dot
+        (lambda (i)
+          (if (>= i len)
+              -1
+              (if (= (string-slice s i (+ i 1)) ".")
+                  i
+                  (find-dot (+ i 1))))) )
+      (define dot (find-dot start))
+      (define parse-int
+        (lambda (i end acc)
+          (if (>= i end)
+              acc
+              (parse-int (+ i 1) end
+                         (+ (* acc 10)
+                            (- (char-code (string-slice s i (+ i 1)))
+                               (char-code "0")))))))
+      (define result
+        (if (= dot -1)
+            (parse-int start len 0)
+            (begin
+              (define whole (parse-int start dot 0))
+              (define frac-start (+ dot 1))
+              (define frac (parse-int frac-start len 0))
+              (define frac-len (- len frac-start))
+              (define pow10
+                (lambda (n acc)
+                  (if (= n 0)
+                      acc
+                      (pow10 (- n 1) (* acc 10)))))
+              (+ whole (/ frac (pow10 frac-len 1))))))
+      (* sign result))))
+
 (define parse-string
   (lambda (text idx)
     (begin

--- a/lispfun/hosted/string_utils.lisp
+++ b/lispfun/hosted/string_utils.lisp
@@ -1,3 +1,13 @@
+(define string-length
+  (lambda (s)
+    (begin
+      (define iter
+        (lambda (i)
+          (if (= (string-slice s i (+ i 1)) "")
+              i
+              (iter (+ i 1)))))
+      (iter 0))))
+
 (define parse-string
   (lambda (text idx)
     (begin

--- a/lispfun/hosted/tests/lisp/numeric.lisp
+++ b/lispfun/hosted/tests/lisp/numeric.lisp
@@ -1,0 +1,19 @@
+(define pass 1)
+(define assert-equal
+  (lambda (result expected)
+    (if (= result expected)
+        1
+        (begin (set! pass 0) 0))))
+
+(assert-equal (<= 2 3) 1)
+(assert-equal (<= 3 3) 1)
+(assert-equal (<= 4 3) 0)
+(assert-equal (>= 3 2) 1)
+(assert-equal (>= 3 3) 1)
+(assert-equal (>= 2 3) 0)
+(assert-equal (abs -4) 4)
+(assert-equal (abs 5) 5)
+(assert-equal (max 2 3) 3)
+(assert-equal (min 2 3) 2)
+
+pass

--- a/lispfun/hosted/tests/lisp/predicates.lisp
+++ b/lispfun/hosted/tests/lisp/predicates.lisp
@@ -1,0 +1,13 @@
+(define pass 1)
+(define assert-equal
+  (lambda (result expected)
+    (if (= result expected)
+        1
+        (begin (set! pass 0) 0))))
+
+(assert-equal (number? 42) (< 0 1))
+(assert-equal (number? "foo") (< 1 0))
+(assert-equal (string? "foo") (< 0 1))
+(assert-equal (string? 42) (< 1 0))
+
+pass

--- a/lispfun/hosted/tests/lisp/stringutils.lisp
+++ b/lispfun/hosted/tests/lisp/stringutils.lisp
@@ -16,6 +16,8 @@
 
 (assert-equal (digits->number "123") 123)
 (assert-equal (digits->number "3.5") 3.5)
+(assert-equal (digits->number "-42") -42)
+(assert-equal (digits->number "-7.25") -7.25)
 
 (define sym (make-symbol "foo"))
 (assert-equal (symbol? sym) 1)

--- a/lispfun/hosted/tests/lisp/stringutils.lisp
+++ b/lispfun/hosted/tests/lisp/stringutils.lisp
@@ -12,6 +12,8 @@
                                 (if (= i 0) "a" (if (= i 1) "b" "c")))))
 (assert-equal built "abc")
 
+(assert-equal (string-length "abc") 3)
+
 (assert-equal (digits->number "123") 123)
 (assert-equal (digits->number "3.5") 3.5)
 

--- a/lispfun/hosted/tests/test_lisp_files.py
+++ b/lispfun/hosted/tests/test_lisp_files.py
@@ -23,6 +23,7 @@ SELFTEST_FILE = os.path.join(os.path.dirname(__file__), "lisp", "selftest.lisp")
 STRINGPARSE_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringparse.lisp")
 STRINGUTILS_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringutils.lisp")
 NUMERIC_FILE = os.path.join(os.path.dirname(__file__), "lisp", "numeric.lisp")
+PRED_FILE = os.path.join(os.path.dirname(__file__), "lisp", "predicates.lisp")
 
 
 def run_file_with_eval(file_path):
@@ -96,5 +97,9 @@ def test_stringutils_script():
 
 def test_numeric_script():
     assert run_file_with_eval2(NUMERIC_FILE) == 1
+
+
+def test_predicates_script():
+    assert run_file_with_eval2(PRED_FILE) == 1
 
 

--- a/lispfun/hosted/tests/test_lisp_files.py
+++ b/lispfun/hosted/tests/test_lisp_files.py
@@ -22,6 +22,7 @@ BASIC_TEST = os.path.join(os.path.dirname(__file__), "lisp", "basic.lisp")
 SELFTEST_FILE = os.path.join(os.path.dirname(__file__), "lisp", "selftest.lisp")
 STRINGPARSE_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringparse.lisp")
 STRINGUTILS_FILE = os.path.join(os.path.dirname(__file__), "lisp", "stringutils.lisp")
+NUMERIC_FILE = os.path.join(os.path.dirname(__file__), "lisp", "numeric.lisp")
 
 
 def run_file_with_eval(file_path):
@@ -91,5 +92,9 @@ def test_stringparse_script():
 
 def test_stringutils_script():
     assert run_file_with_eval2(STRINGUTILS_FILE) == 1
+
+
+def test_numeric_script():
+    assert run_file_with_eval2(NUMERIC_FILE) == 1
 
 

--- a/lispfun/hosted/type_predicates.lisp
+++ b/lispfun/hosted/type_predicates.lisp
@@ -1,0 +1,15 @@
+(define number?
+  (lambda (x)
+    (trap-error
+      (lambda ()
+        (+ x 0)
+        (< 0 1))
+      (lambda (msg) (< 1 0)))))
+
+(define string?
+  (lambda (x)
+    (trap-error
+      (lambda ()
+        (string-length x)
+        (< 0 1))
+      (lambda (msg) (< 1 0)))))

--- a/toy/IDEAS.md
+++ b/toy/IDEAS.md
@@ -29,7 +29,6 @@ now focused on improving the Lisp toy interpreter found in
 - **File I/O primitives** for writing to files, complementing `read-file`.
 - **Exception handling** to manage runtime errors gracefully.
 - **Debugging tools** to trace evaluation and inspect program state.
-- **Full self-hosting**: move the tokenizer and parser to Lisp so the interpreter can boot itself.
 - **Expanded standard library** providing utilities beyond the basic list functions.
 
 ## Task List
@@ -38,5 +37,4 @@ The following items are still planned for the toy interpreter:
 - **Implement quasiquote/unquote** to simplify macro definitions.
 - **Add exception handling** so programs can recover from runtime errors.
 - **Introduce debugging tools** for easier troubleshooting of Lisp code.
-- **Complete self-hosting** by migrating the tokenizer and parser to Lisp.
 - **Expand the standard library** with additional list, string and numeric utilities.

--- a/toy/README.md
+++ b/toy/README.md
@@ -1,4 +1,6 @@
 # Toy Interpreter
 
 The `toy` directory contains a small Lisp interpreter implemented entirely in
-Lisp.  It is loaded by `run_toy.py` after the `eval2` evaluator is available.
+Lisp.  It includes a tokenizer, parser and evaluator so once `eval2` is loaded
+the system runs without relying on the Python implementation.  `run_toy.py`
+loads these pieces and starts a REPL written in Lisp.


### PR DESCRIPTION
## Summary
- implement `string-length` in Lisp
- test the new function in hosted stringutils tests
- document that `string-length` no longer depends on Python

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879859370e8832a84d240af7f02b7d4