### PR TITLE
Fix toy REPL read-line handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ environment are now reimplemented purely in Lisp:
 - `filter` – select elements matching a predicate
 
 String operations and type predicates (`number?`, `string?`, `symbol?`,
-`list?`), along with file I/O, still rely on the Python runtime.
+`list?`), along with file I/O, still rely on the Python runtime.  The
+`string?` predicate now only matches actual string literals so symbols
+are evaluated correctly by the toy interpreter.
 
 The Lisp parser includes basic error reporting so malformed input is handled
 gracefully inside the toy REPL without relying on Python exceptions.

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -80,7 +80,7 @@ def standard_env() -> Environment:
         'length': lambda lst: len(lst),
         'symbol?': lambda x: isinstance(x, Symbol),
         'number?': lambda x: isinstance(x, (int, float)),
-        'string?': lambda x: isinstance(x, str),
+        'string?': lambda x: isinstance(x, String),
         'map': lambda f, lst: [f(item) for item in lst],
         'filter': lambda pred, lst: [item for item in lst if pred(item)],
         'read-file': read_file,

--- a/toy/tests/test_toy_repl_read_line.py
+++ b/toy/tests/test_toy_repl_read_line.py
@@ -22,7 +22,6 @@ def test_python_toy_repl_reads_line(monkeypatch, capsys):
     assert 'hi' in out
 
 
-@pytest.mark.xfail(reason="Known issue with the toy REPL handling read-line")
 def test_lisp_toy_repl_reads_line(monkeypatch, capsys):
     """Lisp REPL implemented in toy interpreter should echo a line read via read-line."""
     env = setup_env()


### PR DESCRIPTION
## Summary
- ensure `string?` only matches string literals
- remove the xfail mark from REPL read-line test
- document improved behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68799019f5b4832a877429a197dcb842