### PR TITLE
Fix toy REPL symbol handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ are evaluated correctly by the toy interpreter.
 
 The Lisp parser includes basic error reporting so malformed input is handled
 gracefully inside the toy REPL without relying on Python exceptions.
+The tokenizer also now returns proper symbol objects so the REPL evaluates
+identifiers correctly when using the toy parser.

--- a/toy/toy-tokenizer.lisp
+++ b/toy/toy-tokenizer.lisp
@@ -53,7 +53,7 @@
                 k)
             k)))
     (set! j (loop j))
-    (list j (string-slice text idx j))))
+    (list j (make-symbol (string-slice text idx j)))))
 
 ; Read a string token starting at index idx
 (define read-string


### PR DESCRIPTION
## Summary
- tokenize Lisp symbols in the toy tokenizer using `make-symbol`
- document the tokenizer change in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879982be434832a8a218aa9464ad6b8