### PR TITLE
Fix hosted evaluator regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ reimplemented purely in Lisp:
 - `number?` – check if a value is numeric
 - `string?` – check if a value is a string
 - `list?` – check if a value is a list
-- `symbol?` – check if a value is a symbol
 - `char-code` – numeric code of a character (digits and `"` handled in Lisp,
   other characters fall back to the host)
 - `chr` – single character from a code (handles digit codes and `"` in Lisp,
   otherwise uses the host implementation)
 - Numeric helpers `<=`, `>=`, `abs`, `max` and `min`
 
-The remaining host-provided primitives are:
+- The remaining host-provided primitives are:
 - low level string helpers `string-slice`, `string-concat`, `make-string`
+- type predicates `symbol?`
 - symbol utility `make-symbol`
 - environment helpers `env-get`, `env-set!` and `make-procedure`
 - file I/O primitives `read-file` and `read-line`

--- a/lispfun/bootstrap/interpreter.py
+++ b/lispfun/bootstrap/interpreter.py
@@ -62,6 +62,8 @@ def kernel_env() -> Environment:
         'env-get': lambda env, var: env.find(var)[var],
         'env-set!': lambda env, var, val: env.__setitem__(var, val),
         'make-procedure': Procedure,
+        'char-code': lambda s: ord(s[0]),
+        'chr': chr,
     })
     return env
 

--- a/lispfun/hosted/type_predicates.lisp
+++ b/lispfun/hosted/type_predicates.lisp
@@ -22,13 +22,3 @@
         (< 0 1))
       (lambda (msg) (< 1 0))))
 )
-
-(define symbol?
-  (lambda (x)
-    (if (number? x)
-        (< 1 0)
-        (if (string? x)
-            (< 1 0)
-            (if (list? x)
-                (< 1 0)
-                (< 0 1))))) )


### PR DESCRIPTION
## Summary
- revert Lisp `symbol?` implementation that broke bootstrap
- ensure kernel env exposes `char-code` and `chr`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c28d80520832a96b6ed98baa96cea